### PR TITLE
bug fix: Support more than just SqlServer at runtime :)

### DIFF
--- a/grate.unittests/CommandLineParsing.cs
+++ b/grate.unittests/CommandLineParsing.cs
@@ -1,9 +1,7 @@
 ﻿using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using grate.Commands;
 using grate.Configuration;
 using grate.Infrastructure;
@@ -216,6 +214,15 @@ namespace grate.unittests
         {
             var cfg = await ParseGrateConfiguration(args);
             cfg?.UserTokens?.Should().HaveCount(expectedCount);
+        }
+
+        [TestCase("", DatabaseType.sqlserver)] // default
+        [TestCase("--dbt=postgresql", DatabaseType.postgresql)]
+        [TestCase("--dbt=mariadb", DatabaseType.mariadb)]
+        public async Task TestDatabaseType(string args, DatabaseType expected)
+        {
+            var cfg = await ParseGrateConfiguration(args);
+            cfg?.DatabaseType.Should().Equals(expected);
         }
 
 

--- a/grate/Migration/DbMigrator.cs
+++ b/grate/Migration/DbMigrator.cs
@@ -19,7 +19,7 @@ namespace grate.Migration
         {
             _logger = logger;
             _hashGenerator = hashGenerator;
-            Configuration = configuration ?? GrateConfiguration.Default;
+            Configuration = configuration ?? throw new ArgumentException(nameof(configuration), "No configuration passed to DbMigrator.  Container setup error?");
             Database = factory.GetService<DatabaseType, IDatabase>(Configuration.DatabaseType);
             StatementSplitter = new StatementSplitter(Database.StatementSeparatorRegex);
         }


### PR DESCRIPTION
Found as part of building the docker sample, `DbMigrator` some Databases weren't registered in the container, and the `GrateConfiguration` wasn't making it to the migrator...