### PR TITLE
Only run msi on release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,13 +122,16 @@ jobs:
      - set-version-number
      - build-standalone
     runs-on: windows-latest
+    if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
     strategy:
       matrix:
         arch: [ "win-x64" ]
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
     - uses: actions/download-artifact@v2
+      if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
       with:
         name: grate-${{ matrix.arch }}-self-contained-${{ needs.set-version-number.outputs.version }}
         path: ${{ matrix.arch }}/


### PR DESCRIPTION
Skip the MSI step altogether on non-release (tagged) builds