### PR TITLE
Set pr:none on devops pipeline trigger

### DIFF
--- a/examples/AzureDevops/azure-pipelines.yml
+++ b/examples/AzureDevops/azure-pipelines.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 variables:
 - name: packageUrl


### PR DESCRIPTION
This should not trigger a build of the Azure Devops example pipeline