### PR TITLE
Proper test reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,10 +254,3 @@ jobs:
         LogLevel: Warning
         TZ: UTC
       
-    - name: Upload Unit Test Results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Unit Test Results (${{ matrix.category }})
-        path: grate.unittests/test-results-${{ matrix.category }}.xml
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-netcore-tool:
-    name: Build .NET Core (global) tool
-
+  build-code:
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
@@ -29,22 +27,26 @@ jobs:
         dotnet-version: 6.0.x
         include-prerelease: false
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore -r linux-x64 grate.unittests/grate.unittests.csproj
     - name: Build
-      #run: dotnet pack ./grate/grate.csproj -c release -p:PackAsTool=true -p:PackageOutputPath=/tmp/grate/nupkg
-      run: dotnet pack ./grate/grate.csproj -p:PackAsTool=true -p:PackageOutputPath=/tmp/grate/nupkg
+      run: dotnet build --no-self-contained grate.unittests/grate.unittests.csproj -r linux-x64 --no-restore -c release -o bin/bin
+
+    - name: Upload built binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: binaries
+        # Note the double bin/bin above. If you add more paths here, you should remove one 'bin', as if there's only one folder, the files are added to the zip root instead.
+        path: |
+          bin   
+        retention-days: 1
 
   analyze:
-    #if: ${{ false }}
     name: Analyze Code Security
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
 
     steps:
     - name: Checkout repository
@@ -72,20 +74,24 @@ jobs:
     name: Run tests
 
     runs-on: ubuntu-latest
+    needs: build-code
+
     strategy:
       matrix:
         category: [ "Basic", "SqlServer", "PostgreSQL", "MariaDB", "Sqlite", "Oracle"  ]
-        #category: [ "Basic" ]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Download binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: binaries    
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
         include-prerelease: false
     - name: Test
-      run: dotnet test --filter FullyQualifiedName~grate.unittests.${{ matrix.category }}  -c Release --logger:"trx;LogFileName=test-results-${{ matrix.category }}.xml"
+      run: dotnet vstest --TestCaseFilter:"FullyQualifiedName~grate.unittests.${{ matrix.category }}" bin/grate.unittests.dll --logger:"trx;LogFileName=test-results-${{ matrix.category }}.xml"
       env:
         LogLevel: Warning
         TZ: UTC
@@ -95,12 +101,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-results-${{ matrix.category }}
-        path: grate.unittests/TestResults/test-results-${{ matrix.category }}.xml
+        #name: test-results
+        path: TestResults/test-results-${{ matrix.category }}.xml
+        retention-days: 1
 
-    # - name: Create test reports
-    #   uses: dorny/test-reporter@v1
-    #   if: always()
-    #   with:
-    #     name: Test reports
-    #     path: grate.unittests/TestResults/test-results-*.xml
-    #     reporter: dotnet-trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,4 +1,4 @@
-name: 'Create test Reports'
+name: 'Create Test Reports'
 on:
   workflow_run:
     workflows: ['CI']                     # runs after CI workflow
@@ -6,26 +6,9 @@ on:
       - completed
 
 jobs:
-  # report:
-  #    runs-on: ubuntu-latest
-  #    name: Create test report
-  #    strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       category: [ "Basic", "SqlServer", "PostgreSQL", "MariaDB", "Sqlite", "Oracle"  ]
-  #       #category: [ "Basic" ]
-
-  #    steps:
-  #     - uses: dorny/test-reporter@v1
-  #       with:
-  #         artifact: test-results-${{ matrix.category }}     # artifact name
-  #         name: Test report (${{ matrix.category }})                     # Name of the check run which will be created
-  #         path: '*.xml'                                            # Path to test results (inside artifact .zip)
-  #         reporter: dotnet-trx                                     # Format of test results     
-
-  report1:
+  report:
      runs-on: ubuntu-latest
-     name: Create test report1
+     name: Create test report
 
      steps:
       - uses: dorny/test-reporter@v1

--- a/grate/NuGet.md
+++ b/grate/NuGet.md
@@ -23,7 +23,7 @@ for more configuration options, see the [documentation](https://erikbra.github.i
 * PostgreSQL
 * MariaDB/MySQL
 * Sqlite
-* _(Oracle support is in the works)_
+* Oracle
 
 Full documentation can be found at [https://erikbra.github.io/grate/](https://erikbra.github.io/grate/).
 


### PR DESCRIPTION
* Create test results per run of tests
* Build just once, and run tests without building
* Skip building dotnet tool on CI
* Separate workflow for creating test reports