### PR TITLE
Issue #22: Solved slow SQL Server tests

### DIFF
--- a/grate.unittests/TestInfrastructure/SqlServerGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/SqlServerGrateTestContext.cs
@@ -14,10 +14,10 @@ class SqlServerGrateTestContext : TestContextBase, IGrateTestContext, IDockerTes
     public int? Port { get; set; }
 
     public string DockerCommand(string serverName, string adminPassword) =>
-        $"run -d --name {serverName} -e ACCEPT_EULA=Y -e SA_PASSWORD={adminPassword} -e MSSQL_PID=Developer -e MSSQL_COLLATION=Danish_Norwegian_CI_AS -P mcr.microsoft.com/mssql/server:2017-latest";
+        $"run -d --name {serverName} -e ACCEPT_EULA=Y -e SA_PASSWORD={adminPassword} -e MSSQL_PID=Developer -e MSSQL_COLLATION=Danish_Norwegian_CI_AS -P mcr.microsoft.com/mssql/server:latest";
 
-    public string AdminConnectionString => $"Data Source=localhost,{Port};Initial Catalog=master;User Id=sa;Password={AdminPassword};Encrypt=false";
-    public string ConnectionString(string database) => $"Data Source=localhost,{Port};Initial Catalog={database};User Id=sa;Password={AdminPassword};Encrypt=false";
+    public string AdminConnectionString => $"Data Source=localhost,{Port};Initial Catalog=master;User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
+    public string ConnectionString(string database) => $"Data Source=localhost,{Port};Initial Catalog={database};User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
 
     public DbConnection GetDbConnection(string connectionString) => new SqlConnection(connectionString);
 
@@ -36,6 +36,6 @@ class SqlServerGrateTestContext : TestContextBase, IGrateTestContext, IDockerTes
         SelectVersion = "SELECT @@VERSION",
     };
 
-    public string ExpectedVersionPrefix => "Microsoft SQL Server 2017";
+    public string ExpectedVersionPrefix => "Microsoft SQL Server 2019";
     public bool SupportsCreateDatabase => true;
 }


### PR DESCRIPTION
  * Turned OFF connection pooling on SQL Server connection string for tests
      - Found several discussions on this, e.g. https://github.com/dotnet/SqlClient/issues/601
      - Tried turning off pooling, and it solved the problem...
    * Upgraded SQL server docker image used in test from 2017-latest to
      latest (2019 at the time) - didn't make any difference, just to stay
      current.