### PR TITLE
Basic "fixing" of incompatibilities in System.Commandline v2.0 beta2

### DIFF
--- a/grate.unittests/Basic/CommandLineParsing.cs
+++ b/grate.unittests/Basic/CommandLineParsing.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading.Tasks;
@@ -122,7 +123,7 @@ public class CommandLineParsing
         cfg?.Transaction.Should().Be(true);
     }
 
-    [TestCase("-t 0")]
+    [TestCase("-t false")]
     [TestCase("--trx false")]
     [TestCase("--transaction false")]
     [TestCase("--transaction=false")]

--- a/grate/Commands/MigrateCommand.cs
+++ b/grate/Commands/MigrateCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using grate.Configuration;
 using grate.Infrastructure;
@@ -116,7 +116,7 @@ public sealed class MigrateCommand : RootCommand
         );
 
     private static Option RunInTransaction() => //new Argument<bool>("-t");
-        new Option<string>(
+        new Option<bool>(
             new[] { "--transaction", "--trx", "-t" },
             "Run the migration in a transaction"
         );

--- a/grate/Program.cs
+++ b/grate/Program.cs
@@ -2,6 +2,7 @@
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 using System.Reflection;
 using System.Threading;

--- a/grate/grate.csproj
+++ b/grate/grate.csproj
@@ -25,6 +25,7 @@ up using modern .NET 6.
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.*" />
     <PackageReference Include="System.CommandLine" Version=" 2.0.0-*" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version=" 2.0.0-*" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.*" />
     <PackageReference Include="Dapper" Version="2.0.*" />
     <PackageReference Include="Npgsql" Version="6.0.*" />


### PR DESCRIPTION
The APIs have been re-written, see https://github.com/dotnet/command-line-api/issues/1537.
Basic workaround is to include the System.CommandLine.NamingConvention dependency, but
we should eventually re-write to use the newer APIs.

This makes it build and work for now, though