### PR TITLE
fix #167: Ensure that a sql server database name that differs only by…

### DIFF
--- a/grate.unittests/Generic/GenericDatabase.cs
+++ b/grate.unittests/Generic/GenericDatabase.cs
@@ -87,6 +87,24 @@ public abstract class GenericDatabase
         Assert.DoesNotThrowAsync(() => migrator.Migrate());
     }
 
+    [Test]
+    public async Task Does_not_needlessly_apply_case_sensitive_database_name_checks_Issue_167()
+    {
+        // There's a bug where if the database name specified by the user differs from the actual database only by case then
+        // Grate currently attempts to create the database again, only for it to fail on the DBMS (Sql Server bug only).
+
+        var db = "CASEDATABASE";
+        await CreateDatabase(db);
+
+        // Check that the database has been created
+        IEnumerable<string> databasesBeforeMigration = await GetDatabases();
+        databasesBeforeMigration.Should().Contain(db);
+
+        await using var migrator = GetMigrator(GetConfiguration(db.ToLower(), true)); // ToLower is important here, this reproduces the bug in #167
+        // There should be no errors running the migration
+        Assert.DoesNotThrowAsync(() => migrator.Migrate());
+    }
+
     protected virtual async Task CreateDatabase(string db)
     {
         using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))

--- a/grate/Migration/SqlServerDatabase.cs
+++ b/grate/Migration/SqlServerDatabase.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Data.Common;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Transactions;
+using Dapper;
 using grate.Configuration;
 using grate.Infrastructure;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+
+using static System.Data.CommandType;
 
 namespace grate.Migration;
 
@@ -67,5 +71,32 @@ public class SqlServerDatabase : AnsiSqlDatabase
         await WaitUntilDatabaseIsReady();
 
         Logger.LogInformation("Database {DbName} successfully restored from path {Path}.", DatabaseName, backupPath);
+    }
+
+    public override async Task<bool> DatabaseExists()
+    {
+        // For Bug #167.  Sql Server is causing issues when the database name passed in differs only in case from one already existing on the server.
+        // There's currently no point adding to ISyntax for this as all the other DBMS's would just be a NOP.
+
+        // We can't use `db_id()` here as Azure Sql won't let you get the db_id of a database other than your current one :(
+        // This should also mean that a SQL server running a Case Sensitive collation _also_ works as expected
+        var sql = $"select database_id from sys.databases where [name] = '{DatabaseName}'"; 
+
+        try
+        {
+            await OpenAdminConnection();
+            var results = await AdminConnection.QueryAsync<int>(sql, commandType: Text);
+
+            return results.Any();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Got error: {ErrorMessage}", ex.Message);
+            throw;
+        }
+        finally
+        {
+            await CloseAdminConnection();
+        }
     }
 }


### PR DESCRIPTION
… case doesn't error without good reason.

Sql Server was the only DBMS that triggered the test so I've applied a Sql specific fix rather than polluting `ISyntax`.

