### PR TITLE
Fix #203:  Missing support for (Admin)CommandTimeout

### DIFF
--- a/grate.unittests/Generic/Running_MigrationScripts/Failing_Scripts.cs
+++ b/grate.unittests/Generic/Running_MigrationScripts/Failing_Scripts.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using System;
+using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -65,6 +66,36 @@ public abstract class Failing_Scripts : MigrationsScriptsBase
         }
 
         scripts.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void Ensure_Command_Timeout_Fires()
+    {
+        var sql = Context.Sql.SleepTwoSeconds;
+
+        if (sql == default)
+        {
+            //I haven't found the sql syntax for all the DBMS's to sleep yet...
+            Assert.Ignore("Db not configured for timeout testing");
+        }
+
+        var db = TestConfig.RandomDatabase();
+        var knownFolders = KnownFolders.In(CreateRandomTempDirectory());
+        var path = MakeSurePathExists(knownFolders.Up);
+        WriteSql(path, "goodnight.sql", sql);
+
+        // run it with a timeout shorter than the 1 second sleep, should timeout
+        var config = Context.GetConfiguration(db, knownFolders) with
+        {
+            CommandTimeout = 1, // shorter than the script runs for
+        };
+
+        Assert.CatchAsync(async () =>
+        {
+            await using var migrator = Context.GetMigrator(config);
+            await migrator.Migrate();
+            Assert.Fail("Should have thrown a timeout exception prior to this!");
+        });
     }
 
     // This does not work for MySql/MariaDB, as it does not support DDL transactions

--- a/grate.unittests/TestInfrastructure/MariaDbGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/MariaDbGrateTestContext.cs
@@ -34,6 +34,7 @@ class MariaDbGrateTestContext : TestContextBase, IGrateTestContext, IDockerTestC
     public SqlStatements Sql => new()
     {
         SelectVersion = "SELECT VERSION()",
+        SleepTwoSeconds = "SELECT SLEEP(2);"
     };
 
 

--- a/grate.unittests/TestInfrastructure/OracleGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/OracleGrateTestContext.cs
@@ -34,6 +34,7 @@ internal class OracleGrateTestContext : TestContextBase, IGrateTestContext, IDoc
     public SqlStatements Sql => new()
     {
         SelectVersion = "SELECT * FROM v$version WHERE banner LIKE 'Oracle%'",
+        SleepTwoSeconds = "sys.dbms_session.sleep(2);"
     };
 
     public string ExpectedVersionPrefix => "Oracle Database 11g Express Edition Release 11.2.0.2.0 - 64bit Production";

--- a/grate.unittests/TestInfrastructure/PostgreSqlGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/PostgreSqlGrateTestContext.cs
@@ -34,6 +34,7 @@ internal class PostgreSqlGrateTestContext : TestContextBase, IGrateTestContext, 
     public SqlStatements Sql => new()
     {
         SelectVersion = "SELECT version()",
+        SleepTwoSeconds = "SELECT pg_sleep(2);"
     };
 
 

--- a/grate.unittests/TestInfrastructure/SqlServerGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/SqlServerGrateTestContext.cs
@@ -34,6 +34,7 @@ class SqlServerGrateTestContext : TestContextBase, IGrateTestContext, IDockerTes
     public SqlStatements Sql => new()
     {
         SelectVersion = "SELECT @@VERSION",
+        SleepTwoSeconds = "WAITFOR DELAY '00:00:02'"
     };
 
     public string ExpectedVersionPrefix => "Microsoft SQL Server 2019";

--- a/grate.unittests/TestInfrastructure/SqlStatements.cs
+++ b/grate.unittests/TestInfrastructure/SqlStatements.cs
@@ -3,4 +3,5 @@
 public record SqlStatements
 {
     public string SelectVersion { get; init; } = default!;
+    public string SleepTwoSeconds { get; init; } = default!;
 }

--- a/grate/Migration/AnsiSqlDatabase.cs
+++ b/grate/Migration/AnsiSqlDatabase.cs
@@ -18,7 +18,7 @@ public abstract class AnsiSqlDatabase : IDatabase
 {
     private string SchemaName { get; set; } = "";
 
-    private GrateConfiguration? _configuration;
+    protected GrateConfiguration? Config { get; private set; }
 
     protected ILogger Logger { get; }
     // ReSharper disable once InconsistentNaming
@@ -58,7 +58,7 @@ public abstract class AnsiSqlDatabase : IDatabase
         ConnectionString = configuration.ConnectionString;
         AdminConnectionString = configuration.AdminConnectionString;
         SchemaName = configuration.SchemaName;
-        _configuration = configuration;
+        Config = configuration;
         return Task.CompletedTask;
     }
 
@@ -87,7 +87,7 @@ public abstract class AnsiSqlDatabase : IDatabase
             using var s = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
             var sql = _syntax.CreateDatabase(DatabaseName, Password);
 
-            await ExecuteNonQuery(AdminConnection, sql);
+            await ExecuteNonQuery(AdminConnection, sql, Config?.AdminCommandTimeout);
             s.Complete();
         }
 
@@ -102,7 +102,7 @@ public abstract class AnsiSqlDatabase : IDatabase
             using var s = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
             await CloseConnection(); // try and ensure there's nobody else in there...
             await OpenAdminConnection();
-            await ExecuteNonQuery(AdminConnection, _syntax.DropDatabase(DatabaseName));
+            await ExecuteNonQuery(AdminConnection, _syntax.DropDatabase(DatabaseName), Config?.AdminCommandTimeout);
             s.Complete();
         }
     }
@@ -178,7 +178,7 @@ public abstract class AnsiSqlDatabase : IDatabase
     {
         if (SupportsSchemas && !await RunSchemaExists())
         {
-            await ExecuteNonQuery(Connection, _syntax.CreateSchema(SchemaName));
+            await ExecuteNonQuery(Connection, _syntax.CreateSchema(SchemaName), Config?.CommandTimeout);
         }
     }
 
@@ -209,7 +209,7 @@ CREATE TABLE {ScriptsRunTable}(
 
         if (!await ScriptsRunTableExists())
         {
-            await ExecuteNonQuery(Connection, createSql);
+            await ExecuteNonQuery(Connection, createSql, Config?.CommandTimeout);
         }
     }
 
@@ -231,7 +231,7 @@ CREATE TABLE {ScriptsRunErrorsTable}(
 )";
         if (!await ScriptsRunErrorsTableExists())
         {
-            await ExecuteNonQuery(Connection, createSql);
+            await ExecuteNonQuery(Connection, createSql, Config?.CommandTimeout);
         }
     }
 
@@ -249,7 +249,7 @@ CREATE TABLE {VersionTable}(
 )";
         if (!await VersionTableExists())
         {
-            await ExecuteNonQuery(Connection, createSql);
+            await ExecuteNonQuery(Connection, createSql, Config?.CommandTimeout);
         }
     }
 
@@ -327,14 +327,14 @@ VALUES(@newVersion, @entryDate, @modifiedDate, @enteredBy)
     {
         Logger.LogTrace("[SQL] Running (on connection '{ConnType}'): \n{Sql}", connectionType.ToString(), sql);
 
-        var conn = connectionType switch
+        var (conn, timeout) = connectionType switch
         {
-            ConnectionType.Default => Connection,
-            ConnectionType.Admin => AdminConnection,
+            ConnectionType.Default => (Connection, Config?.CommandTimeout),
+            ConnectionType.Admin => (AdminConnection, Config?.AdminCommandTimeout),
             _ => throw new ArgumentOutOfRangeException(nameof(connectionType), connectionType, "Unknown connection type: " + connectionType)
         };
 
-        await ExecuteNonQuery(conn, sql);
+        await ExecuteNonQuery(conn, sql, timeout);
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local
@@ -485,14 +485,19 @@ VALUES (@version, @scriptName, @sql, @errorSql, @errorMessage, @now, @now, @usr)
         return await conn.ExecuteAsync(sql, parameters);
     }
 
-    protected async Task ExecuteNonQuery(DbConnection conn, string sql)
+    protected async Task ExecuteNonQuery(DbConnection conn, string sql, int? timeout)
     {
         Logger.LogTrace("SQL: {Sql}", sql);
 
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.CommandType = CommandType.Text;
-        cmd.CommandTimeout = _configuration?.CommandTimeout ?? throw new InvalidOperationException("Unable to get CommandTimeout from configuration");
+
+        if (timeout.HasValue)
+        {
+            cmd.CommandTimeout = timeout.Value;
+        }
+
         await cmd.ExecuteNonQueryAsync();
     }
 

--- a/grate/Migration/OracleDatabase.cs
+++ b/grate/Migration/OracleDatabase.cs
@@ -19,7 +19,7 @@ public class OracleDatabase : AnsiSqlDatabase
         : base(logger, new OracleSyntax())
     {
     }
-        
+
     public override bool SupportsDdlTransactions => false;
     protected override bool SupportsSchemas => false;
 
@@ -39,8 +39,8 @@ FROM
             ROW_NUMBER() OVER (ORDER BY version DESC) AS version_row_number 
     FROM {VersionTable})
 WHERE  version_row_number <= 1
-"; 
-        
+";
+
     protected override async Task CreateScriptsRunTable()
     {
         if (!await ScriptsRunTableExists())
@@ -50,7 +50,7 @@ WHERE  version_row_number <= 1
             await CreateIdInsertTrigger(ScriptsRunTable);
         }
     }
-        
+
     protected override async Task CreateScriptsRunErrorsTable()
     {
         if (!await ScriptsRunErrorsTableExists())
@@ -75,9 +75,9 @@ WHERE  version_row_number <= 1
             await CreateIdInsertTrigger(VersionTable);
         }
     }
-        
+
     protected override string Parameterize(string sql) => sql.Replace("@", ":");
-    protected override object Bool(bool source) => source ? '1': '0';
+    protected override object Bool(bool source) => source ? '1' : '0';
 
     public override async Task<long> VersionTheDatabase(string newVersion)
     {
@@ -96,7 +96,7 @@ RETURNING id into :id
         };
         var dynParams = new DynamicParameters(parameters);
         dynParams.Add(":id", dbType: DbType.Int64, direction: ParameterDirection.Output);
-            
+
         await Connection.ExecuteAsync(
             sql,
             dynParams);
@@ -121,16 +121,16 @@ RETURNING id into :id
     {
         var tokens = connectionString?.Split(";", RemoveEmptyEntries | TrimEntries) ?? Enumerable.Empty<string>();
         var keyPairs = tokens.Select(t => t.Split("=", TrimEntries));
-        return keyPairs.ToDictionary(pair => pair[0], pair => (string?) pair[1]);
+        return keyPairs.ToDictionary(pair => pair[0], pair => (string?)pair[1]);
     }
-        
-    private static string? GetValue(IDictionary<string, string?> dictionary, string key) => 
+
+    private static string? GetValue(IDictionary<string, string?> dictionary, string key) =>
         dictionary.TryGetValue(key, out string? value) ? value : null;
 
     private async Task CreateIdSequence(string table)
     {
         var sql = $"CREATE SEQUENCE {table}_seq";
-        await ExecuteNonQuery(Connection, sql);
+        await ExecuteNonQuery(Connection, sql, Config?.CommandTimeout);
     }
 
     private async Task CreateIdInsertTrigger(string table)
@@ -142,6 +142,6 @@ FOR EACH ROW
 BEGIN
   SELECT {table}_seq.nextval INTO :new.id FROM dual;
 END;";
-        await ExecuteNonQuery(Connection, sql);
+        await ExecuteNonQuery(Connection, sql, Config?.CommandTimeout);
     }
 }


### PR DESCRIPTION
Yep, we missed applying the config values 🤦

This doesn't have perfect test coverage but is better than we had before.

I also feel like we should be injecting the `GrateConfiguration` into `AnsiDatabase` rather than relying on the values passed into `InitializeConnections`, but that refactoring is a bridge too far for me atm due to a shortage of time.