### PR TITLE
Add note about `Allow User Variables` in MySQL to breaking RH changes

### DIFF
--- a/docs/MigratingFromRoundhousE.md
+++ b/docs/MigratingFromRoundhousE.md
@@ -27,6 +27,8 @@ grate is built using the new [`System.CommandLine`](https://github.com/dotnet/co
 
 - The `--verbose` flag has been changed to a `--verbosity` flag, accepting the values of `<Critical|Debug|Error|Information|None|Trace|Warning>` (see [the MS docs](https://docs.microsoft.com/dotnet/api/Microsoft.Extensions.Logging.LogLevel) for details)
 
+- The `Allow User Variables` connection string option for MySQL connections (used in SPROCs) is no longer set by default.
+
 
 ## RH Features that aren't yet in grate
 


### PR DESCRIPTION
This was encountered during a migration from RoundhousE when using a MySQL connection

For example, here is where it used to be set in RH: https://github.com/chucknorris/roundhouse/blob/0f17f6967a1b3a5bb1d1b63f3574a7e8ba3e1294/product/roundhouse.databases.mysql/MySqlDatabase.cs#L48-L54

If this is not intentional, let me know and I'll create an Issue instead with this feature request.