### PR TITLE
Bug #219: Scripts that should always run, even on failure, do not run on failure

### DIFF
--- a/grate.unittests/Generic/Running_MigrationScripts/Failing_Scripts.cs
+++ b/grate.unittests/Generic/Running_MigrationScripts/Failing_Scripts.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Data.Common;
+﻿using System.Data.Common;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Transactions;
 using Dapper;
@@ -36,7 +37,7 @@ public abstract class Failing_Scripts : MigrationsScriptsBase
     }
 
     [Test]
-    public async Task Are_Inserted_Into_ScriptRunErrors_Table()
+    public async Task Inserts_Failed_Scripts_Into_ScriptRunErrors_Table()
     {
         var db = TestConfig.RandomDatabase();
 
@@ -67,7 +68,7 @@ public abstract class Failing_Scripts : MigrationsScriptsBase
 
         scripts.Should().HaveCount(1);
     }
-
+    
     [Test]
     public void Ensure_Command_Timeout_Fires()
     {
@@ -126,44 +127,92 @@ public abstract class Failing_Scripts : MigrationsScriptsBase
         });
     }
 
-    // This does not work for MySql/MariaDB, as it does not support DDL transactions
-    // [Test]
-    // public async Task Makes_Whole_Transaction_Rollback()
-    // {
-    //     var db = TestConfig.RandomDatabase();
-    //
-    //     GrateMigrator? migrator;
-    //     
-    //     var knownFolders = KnownFolders.In(CreateRandomTempDirectory());
-    //     CreateDummySql(knownFolders.Up);
-    //     CreateInvalidSql(knownFolders.Up);
-    //     
-    //     await using (migrator = GrateTestContext.GetMigrator(db, true, knownFolders))
-    //     {
-    //         try
-    //         {
-    //             await migrator.Migrate();
-    //         }
-    //         catch (DbException)
-    //         {
-    //         }
-    //     }
-    //
-    //     string[] scripts;
-    //     string sql = $"SELECT script_name FROM {GrateTestContext.Syntax.TableWithSchema("grate", "ScriptsRun")}";
-    //     
-    //     await using (var conn = GrateTestContext.CreateDbConnection(db))
-    //     {
-    //         scripts = (await conn.QueryAsync<string>(sql)).ToArray();
-    //     }
-    //
-    //     scripts.Should().BeEmpty();
-    // }
+    [Test]
+    [TestCaseSource(nameof(ShouldStillBeRunOnRollback))]
+    public virtual async Task Still_Runs_The_Scripts_In(MigrationsFolder folder)
+    {
+        var filename = folder.Name + "_jalla1.sql";
+        var scripts = await RunMigration(folder, filename);
+        scripts.Should().Contain(filename);
+    }
 
-    private static void CreateInvalidSql(MigrationsFolder? folder)
+    [Test]
+    [TestCaseSource(nameof(ShouldNotBeRunOnRollback))]
+    public virtual async Task Rolls_Back_Runs_Of_Scripts_In(MigrationsFolder folder)
+    {
+        if (!Context.SupportsTransaction)
+        {
+            Assert.Ignore("DDL transactions not supported, skipping tests");
+        }
+
+        var scripts = await RunMigration(folder, folder.Name + "_jalla1.sql");
+        scripts.Should().BeEmpty();
+    }
+
+
+    private async Task<string[]> RunMigration(MigrationsFolder folder, string filename)
+    {
+        string[] scripts;
+
+        var db = TestConfig.RandomDatabase();
+
+        GrateMigrator? migrator;
+
+        var knownFolders = Folders;
+        CreateDummySql(folder, filename);
+        CreateInvalidSql(knownFolders.Up);
+
+        await using (migrator = Context.GetMigrator(db, knownFolders, true))
+        {
+            try
+            {
+                await migrator.Migrate();
+            }
+            catch (DbException)
+            {
+            }
+        }
+
+        string sql = $"SELECT script_name FROM {Context.Syntax.TableWithSchema("grate", "ScriptsRun")}";
+
+        await using (var conn = Context.CreateDbConnection(db))
+        {
+            scripts = (await conn.QueryAsync<string>(sql)).ToArray();
+        }
+
+        return scripts;
+    }
+
+    protected static void CreateInvalidSql(MigrationsFolder? folder)
     {
         var dummySql = "SELECT TOP";
         var path = MakeSurePathExists(folder);
         WriteSql(path, "2_failing.sql", dummySql);
     }
+
+    private static readonly DirectoryInfo Root = TestConfig.CreateRandomTempDirectory();
+    private static readonly KnownFolders Folders = KnownFolders.In(Root);
+
+    private static readonly object?[] ShouldStillBeRunOnRollback =
+    {
+        GetTestCase(Folders.BeforeMigration), GetTestCase(Folders.AlterDatabase), GetTestCase(Folders.Permissions),
+        GetTestCase(Folders.AfterMigration),
+    };
+
+    private static readonly object?[] ShouldNotBeRunOnRollback =
+    {
+        GetTestCase(Folders.RunAfterCreateDatabase), GetTestCase(Folders.RunBeforeUp), GetTestCase(Folders.Up),
+        GetTestCase(Folders.RunFirstAfterUp), GetTestCase(Folders.Functions), GetTestCase(Folders.Views),
+        GetTestCase(Folders.Sprocs), GetTestCase(Folders.Triggers), GetTestCase(Folders.Indexes),
+        GetTestCase(Folders.RunAfterOtherAnyTimeScripts),
+    };
+
+    private static TestCaseData GetTestCase(
+        MigrationsFolder? folder,
+        [CallerArgumentExpression("folder")] string migrationsFolderDefinitionName = ""
+    ) =>
+        new TestCaseData(folder)
+            .SetArgDisplayNames(
+                migrationsFolderDefinitionName
+            );
 }

--- a/grate.unittests/TestInfrastructure/IGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/IGrateTestContext.cs
@@ -68,16 +68,28 @@ public interface IGrateTestContext
 
     public GrateMigrator GetMigrator(string databaseName, KnownFolders knownFolders)
     {
-        return GetMigrator(databaseName, knownFolders, null);
+        return GetMigrator(databaseName, knownFolders, null, false);
+    }
+    
+    public GrateMigrator GetMigrator(string databaseName, KnownFolders knownFolders, bool runInTransaction)
+    {
+        return GetMigrator(databaseName, knownFolders, null, runInTransaction);
+    }
+    
+    
+    public GrateMigrator GetMigrator(string databaseName, KnownFolders knownFolders, string? env)
+    {
+        return GetMigrator(databaseName, knownFolders, env, false);
     }
 
-    public GrateMigrator GetMigrator(string databaseName, KnownFolders knownFolders, string? env)
+    public GrateMigrator GetMigrator(string databaseName, KnownFolders knownFolders, string? env, bool runInTransaction)
     {
         var config = DefaultConfiguration with
         {
             ConnectionString = ConnectionString(databaseName),
             KnownFolders = knownFolders,
             Environment = env != null ? new GrateEnvironment(env) : null,
+            Transaction = runInTransaction
         };
 
         return GetMigrator(config);

--- a/grate/Migration/GrateMigrator.cs
+++ b/grate/Migration/GrateMigrator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -74,33 +75,39 @@ public class GrateMigrator : IAsyncDisposable
         }
 
         TransactionScope? scope = null;
+        await dbMigrator.OpenConnection();
+            
+        // Run these first without a transaction, to make sure the tables are created even on a potential rollback
+        await CreateGrateStructure(dbMigrator);
+
+        var (versionId, newVersion) = await VersionTheDatabase(dbMigrator);
+
+        Separator('=');
+        _logger.LogInformation("Migration Scripts");
+        Separator('=');
+
+        // This one should not be necessary, we throw on assignment if null
+        System.Diagnostics.Debug.Assert(knownFolders != null, nameof(knownFolders) + " != null");
+
+        await BeforeMigration(knownFolders, changeDropFolder, versionId);
+
+        if (config.AlterDatabase)
+        {
+            await AlterDatabase(dbMigrator, knownFolders, changeDropFolder, versionId);
+        }
+
+        await dbMigrator.CloseConnection();
+
+        Exception? exception = default;
+            
         try
         {
-            // Run these first without a transaction, to make sure the tables are created even on a potential rollback
-            await CreateGrateStructure(dbMigrator);
-
             // Start the transaction, if configured
             if (runInTransaction)
             {
                 scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
             }
-
             await dbMigrator.OpenConnection();
-            var (versionId, newVersion) = await VersionTheDatabase(dbMigrator);
-
-            Separator('=');
-            _logger.LogInformation("Migration Scripts");
-            Separator('=');
-
-            // This one should not be necessary, we throw on assignment if null
-            System.Diagnostics.Debug.Assert(knownFolders != null, nameof(knownFolders) + " != null");
-
-            await BeforeMigration(knownFolders, changeDropFolder, versionId);
-
-            if (config.AlterDatabase)
-            {
-                await AlterDatabase(dbMigrator, knownFolders, changeDropFolder, versionId);
-            }
 
             if (databaseCreated)
             {
@@ -116,14 +123,31 @@ public class GrateMigrator : IAsyncDisposable
             await LogAndProcess(knownFolders.Triggers!, changeDropFolder, versionId, ConnectionType.Default);
             await LogAndProcess(knownFolders.Indexes!, changeDropFolder, versionId, ConnectionType.Default);
             await LogAndProcess(knownFolders.RunAfterOtherAnyTimeScripts!, changeDropFolder, versionId, ConnectionType.Default);
+            
+            await dbMigrator.CloseConnection();
 
             scope?.Complete();
+        }catch (DbException ex)
+        {
+            // Catch exceptions, so that we run the rest of the scripts, that should always be run.
+            exception = ex;
+        }
+        finally
+        {
+            scope?.Dispose();
+        }
 
             using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             {
+            await dbMigrator.OpenConnection();
                 await LogAndProcess(knownFolders.Permissions!, changeDropFolder, versionId, ConnectionType.Default);
                 await LogAndProcess(knownFolders.AfterMigration!, changeDropFolder, versionId, ConnectionType.Default);
             }
+
+        if (exception is not null)
+        {
+            throw exception;
+        }
 
             _logger.LogInformation(
                 "\n\ngrate v{Version} has grated your database ({DatabaseName})! You are now at version {NewVersion}. All changes and backups can be found at \"{ChangeDropFolder}\".",
@@ -134,11 +158,6 @@ public class GrateMigrator : IAsyncDisposable
 
             Separator(' ');
 
-        }
-        finally
-        {
-            scope?.Dispose();
-        }
 
     }
 
@@ -164,8 +183,6 @@ public class GrateMigrator : IAsyncDisposable
 
     private async Task CreateGrateStructure(IDbMigrator dbMigrator)
     {
-        await dbMigrator.OpenConnection();
-
         Separator('=');
         _logger.LogInformation("Grate Structure");
         Separator('=');
@@ -178,8 +195,6 @@ public class GrateMigrator : IAsyncDisposable
         {
             await dbMigrator.RunSupportTasks();
         }
-
-        await dbMigrator.CloseConnection();
     }
 
     private async Task<(long, string)> VersionTheDatabase(IDbMigrator dbMigrator)

--- a/grate/Migration/OracleDatabase.cs
+++ b/grate/Migration/OracleDatabase.cs
@@ -112,7 +112,7 @@ RETURNING id into :id
     {
         get
         {
-            var tokens = Tokenize(_connection?.ConnectionString);
+            var tokens = Tokenize(Connection.ConnectionString);
             return GetValue(tokens, "Proxy User Id") ?? GetValue(tokens, "User ID") ?? base.DatabaseName;
         }
     }

--- a/grate/Migration/SqLiteDatabase.cs
+++ b/grate/Migration/SqLiteDatabase.cs
@@ -35,7 +35,7 @@ name = '{fullTableName}';
     /// <returns></returns>
     public override Task DropDatabase()
     {
-        var db = _connection?.DataSource;
+        var db = Connection.DataSource;
 
         SqliteConnection.ClearAllPools();
 


### PR DESCRIPTION
Fixes Bug #219

* Fixed transaction handling - SQL connections that should run in an autonomous inner transaction
  (not affected by rollback of any other active 'outer' transactions) need to be opened after
  a `TransactionScope` with `TransactionScopeOptions.Suppress` is started.
* Added a few (failing) tests on scripts to run even on failure
* Fixed flow in GrateMigrator to run 'Run even on failure' scripts even if other scripts fail