### PR TITLE
Closes #142: Reduce console output, esp when folder is missing or empty.

### DIFF
--- a/grate/Migration/DbMigrator.cs
+++ b/grate/Migration/DbMigrator.cs
@@ -78,7 +78,7 @@ public class DbMigrator : IDbMigrator
 
         async Task<bool> LogAndRunSql()
         {
-            _logger.LogInformation(" Running {ScriptName} on {ServerName} - {DatabaseName}.", scriptName, Database.ServerName, Database.DatabaseName);
+            _logger.LogInformation("  Running '{ScriptName}'.", scriptName);
 
             if (Configuration.DryRun)
             {

--- a/grate/Migration/GrateMigrator.cs
+++ b/grate/Migration/GrateMigrator.cs
@@ -302,7 +302,7 @@ public class GrateMigrator : IAsyncDisposable
 
         if (!anySqlRun)
         {
-            _logger.LogDebug("  No sql run, either an empty folder, or all files run against destination previously.");
+            _logger.LogDebug("No sql run, either an empty folder, or all files run against destination previously.");
         }
 
     }

--- a/grate/Migration/GrateMigrator.cs
+++ b/grate/Migration/GrateMigrator.cs
@@ -302,7 +302,7 @@ public class GrateMigrator : IAsyncDisposable
 
         if (!anySqlRun)
         {
-            _logger.LogDebug("No sql run, either an empty folder, or all files run against destination previously.");
+            _logger.LogInformation(" No sql run, either an empty folder, or all files run against destination previously.");
         }
 
     }

--- a/grate/Migration/GrateMigrator.cs
+++ b/grate/Migration/GrateMigrator.cs
@@ -241,11 +241,11 @@ public class GrateMigrator : IAsyncDisposable
             return;
         }
 
-        if (!folder.Path.EnumerateFiles().Any())
+        if (!folder.Path.EnumerateFileSystemInfos().Any()) // Ensure we check for subdirectories as well as files
         {
             _logger.LogInformation("Skipping '{FolderName}', {Path} is empty.", folder.Name, folder.Path);
             return;
-        } 
+        }
 
         Separator(' ');
 


### PR DESCRIPTION
First cut at reducing output noise, I'm keen for feedback from those with opinions :)

I've opted to remove the Server Name/Database name from every script run line as it seemed a little unnecessary, but this does break back-compat with RH messages.... but so does this entire PR...

There's a few things I'm personally not super happy with, like adding a log line full of spaces just to effectively `Console.WrinteLine()`, but baby steps.

Let me know if you'd like the LogLevel or content of any of the messages changed.


