### PR TITLE
Remove net5 from build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,6 @@ jobs:
       #is-release: 'true'
     
     steps:
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 5.0.x
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
@@ -49,7 +45,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
@@ -87,7 +83,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
@@ -242,7 +238,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
@@ -86,7 +86,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: binaries    
-    - name: Setup .NET
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x


### PR DESCRIPTION
Remove the unnecessary "Install dotnet 5" step from the Github build pipeline - it produces a warning