### PR TITLE
fix #230: Fix schema (in)sensitive casing issue

### DIFF
--- a/grate.unittests/Generic/Running_MigrationScripts/Versioning_The_Database.cs
+++ b/grate.unittests/Generic/Running_MigrationScripts/Versioning_The_Database.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
@@ -101,32 +101,4 @@ public abstract class Versioning_The_Database : MigrationsScriptsBase
         version.status.Should().Be(MigrationStatus.InProgress);
     }
 
-    [Test]
-    public async Task Bug230_Uses_Server_Casing_Rules_For_Schema()
-    {
-        //for bug #230 - when targeting an existing schema use the servers casing rules, not .Net's
-        var db = TestConfig.RandomDatabase();
-        var parent = CreateRandomTempDirectory();
-        var knownFolders = FoldersConfiguration.Default(null);
-
-        CreateDummySql(parent, knownFolders[Sprocs]); // make sure there's something that could be logged...
-
-        await using (var migrator = Context.GetMigrator(db, parent, knownFolders))
-        {
-            await migrator.Migrate();
-            Assert.True(await migrator.DbMigrator.Database.VersionTableExists()); // we migrated into the `grate` schema.
-        }
-
-        // Now we'll run again with the same name but different cased schema
-        var grateConfig = Context.GetConfiguration(db, parent, knownFolders) with
-        {
-            SchemaName = "GRATE"
-        };
-
-        await using (var migrator = Context.GetMigrator(grateConfig))
-        {
-            await migrator.Migrate(); // should either reuse the existing schema if a case-insensitive server, or create a new second schema for use if case-sensitive.
-            Assert.True(await migrator.DbMigrator.Database.VersionTableExists()); // we migrated into the `GRATE` schema, which may be the same as 'grate' depending on server settings.
-        }
-    }
 }

--- a/grate.unittests/SqlServer/Running_MigrationScripts/Versioning_The_Database.cs
+++ b/grate.unittests/SqlServer/Running_MigrationScripts/Versioning_The_Database.cs
@@ -1,12 +1,47 @@
+﻿using System.Threading.Tasks;
+using grate.Configuration;
 using grate.unittests.TestInfrastructure;
 using NUnit.Framework;
+
+using static grate.Configuration.KnownFolderKeys;
 
 namespace grate.unittests.SqlServer.Running_MigrationScripts;
 
 [TestFixture]
 [Category("SqlServer")]
+[NonParallelizable]
 // ReSharper disable once InconsistentNaming
 public class Versioning_The_Database: Generic.Running_MigrationScripts.Versioning_The_Database
 {
     protected override IGrateTestContext Context => GrateTestContext.SqlServer;
+
+
+    [Test]
+    public async Task Bug230_Uses_Server_Casing_Rules_For_Schema()
+    {
+        //for bug #230 - when targeting an existing schema use the servers casing rules, not .Net's
+        var db = TestConfig.RandomDatabase();
+        var parent = CreateRandomTempDirectory();
+        var knownFolders = FoldersConfiguration.Default(null);
+
+        CreateDummySql(parent, knownFolders[Sprocs]); // make sure there's something that could be logged...
+
+        await using (var migrator = Context.GetMigrator(db, parent, knownFolders))
+        {
+            await migrator.Migrate();
+            Assert.True(await migrator.DbMigrator.Database.VersionTableExists()); // we migrated into the `grate` schema.
+        }
+
+        // Now we'll run again with the same name but different cased schema
+        var grateConfig = Context.GetConfiguration(db, parent, knownFolders) with
+        {
+            SchemaName = "GRATE"
+        };
+
+        await using (var migrator = Context.GetMigrator(grateConfig))
+        {
+            await migrator.Migrate(); // should either reuse the existing schema if a case-insensitive server, or create a new second schema for use if case-sensitive.
+            Assert.True(await migrator.DbMigrator.Database.VersionTableExists()); // we migrated into the `GRATE` schema, which may be the same as 'grate' depending on server settings.
+        }
+    }
 }

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Versioning_The_Database.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Versioning_The_Database.cs
@@ -6,7 +6,7 @@ namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
     [TestFixture]
     [Category("SqlServerCaseSensitive")]
     // ReSharper disable once InconsistentNaming
-    public class Versioning_The_Database : Generic.Running_MigrationScripts.Versioning_The_Database
+    public class Versioning_The_Database : grate.unittests.SqlServer.Running_MigrationScripts.Versioning_The_Database
     {
         protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
     }

--- a/grate/Migration/PostgreSqlDatabase.cs
+++ b/grate/Migration/PostgreSqlDatabase.cs
@@ -8,7 +8,7 @@ namespace grate.Migration;
 
 public class PostgreSqlDatabase : AnsiSqlDatabase
 {
-    public PostgreSqlDatabase(ILogger<PostgreSqlDatabase> logger) 
+    public PostgreSqlDatabase(ILogger<PostgreSqlDatabase> logger)
         : base(logger, new PostgreSqlSyntax())
     { }
 
@@ -19,5 +19,19 @@ public class PostgreSqlDatabase : AnsiSqlDatabase
     public override Task RestoreDatabase(string backupPath)
     {
         throw new System.NotImplementedException("Restoring a database from file is not currently supported for  Postgresql.");
+    }
+
+    protected override string ExistsSql(string tableSchema, string fullTableName)
+    {
+        // For #230.  Postgres tables are lowercase by default unless you quote them when created, which we do.  We _don't_ quote the schema though, so it will always be lowercase
+        // Ensure the table check uses the lowercase version of anything we're passed, as that's what we would have created.
+        return base.ExistsSql(tableSchema.ToLower(), fullTableName);
+    }
+
+    protected override string ExistsSql(string tableSchema, string fullTableName, string columnName)
+    {
+        // For #230.  Postgres tables are lowercase by default unless you quote them when created, which we do.  We _don't_ quote the schema though, so it will always be lowercase
+        // Ensure the table check uses the lowercase version of anything we're passed, as that's what we would have created.
+        return base.ExistsSql(tableSchema.ToLower(), fullTableName, columnName);
     }
 }

--- a/grate/Migration/SqLiteDatabase.cs
+++ b/grate/Migration/SqLiteDatabase.cs
@@ -10,9 +10,9 @@ namespace grate.Migration;
 public class SqliteDatabase : AnsiSqlDatabase
 {
     private static readonly SqliteSyntax Syntax = new();
-            
-        
-    public SqliteDatabase(ILogger<SqliteDatabase> logger) 
+
+
+    public SqliteDatabase(ILogger<SqliteDatabase> logger)
         : base(logger, Syntax)
     { }
 
@@ -24,8 +24,9 @@ public class SqliteDatabase : AnsiSqlDatabase
         $@"
 SELECT name FROM sqlite_master 
 WHERE type ='table' AND 
-name = '{fullTableName}';
-";
+name = '{fullTableName}' COLLATE NOCASE;
+"; // #230: Correct mismatched schema casing, sqllite is case-insensitive but the string comparisons in queries _are_ case sensitive by default
+
 
     protected override string ExistsSql(string tableSchema, string fullTableName, string columnName) =>
     $@"SELECT * FROM pragma_table_info('{fullTableName}')
@@ -47,7 +48,7 @@ WHERE name='{columnName}'";
         {
             File.Delete(db);
         }
-            
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
Had some merge issues but think I'm there.

Assorted changes to DBMS's that are (generally) case insensitive.

PGSql is a little interesting with case-sensitive tables but case insensitive schemas (as currently implemented), but so be it.

There's possibly an option to bypass the `Exists` checks entirely for those DBMS's that support `create table if not exists` syntax, but that's a bridge too far for me time-wise atm.