### PR TITLE
fix: Added tests using case sensitive Sql server

### DIFF
--- a/grate.unittests/Generic/GenericDatabase.cs
+++ b/grate.unittests/Generic/GenericDatabase.cs
@@ -91,23 +91,6 @@ public abstract class GenericDatabase
         Assert.DoesNotThrowAsync(() => migrator.Migrate());
     }
 
-    [Test]
-    public async Task Does_not_needlessly_apply_case_sensitive_database_name_checks_Issue_167()
-    {
-        // There's a bug where if the database name specified by the user differs from the actual database only by case then
-        // Grate currently attempts to create the database again, only for it to fail on the DBMS (Sql Server bug only).
-
-        var db = "CASEDATABASE";
-        await CreateDatabase(db);
-
-        // Check that the database has been created
-        IEnumerable<string> databasesBeforeMigration = await GetDatabases();
-        databasesBeforeMigration.Should().Contain(db);
-
-        await using var migrator = GetMigrator(GetConfiguration(db.ToLower(), true)); // ToLower is important here, this reproduces the bug in #167
-        // There should be no errors running the migration
-        Assert.DoesNotThrowAsync(() => migrator.Migrate());
-    }
 
     protected Task CreateDatabase(string db) => CreateDatabaseFromConnectionString(db, Context.ConnectionString(db));
 
@@ -172,9 +155,9 @@ public abstract class GenericDatabase
     protected virtual bool ThrowOnMissingDatabase => true;
 
 
-    private GrateMigrator GetMigrator(GrateConfiguration config) => Context.GetMigrator(config);
+    protected GrateMigrator GetMigrator(GrateConfiguration config) => Context.GetMigrator(config);
 
-    private GrateConfiguration GetConfiguration(string databaseName, bool createDatabase)
+    protected GrateConfiguration GetConfiguration(string databaseName, bool createDatabase)
         => GetConfiguration(databaseName, createDatabase, Context.AdminConnectionString);
     
 

--- a/grate.unittests/SqlServer/Database.cs
+++ b/grate.unittests/SqlServer/Database.cs
@@ -1,3 +1,6 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
 using grate.unittests.TestInfrastructure;
 using NUnit.Framework;
 
@@ -8,5 +11,23 @@ namespace grate.unittests.SqlServer;
 public class Database: Generic.GenericDatabase
 {
     protected override IGrateTestContext Context => GrateTestContext.SqlServer;
-        
+
+    [Test]
+    public async Task Does_not_needlessly_apply_case_sensitive_database_name_checks_Issue_167()
+    {
+        // There's a bug where if the database name specified by the user differs from the actual database only by case then
+        // Grate currently attempts to create the database again, only for it to fail on the DBMS (Sql Server, case insensitive  bug only).
+
+        var db = "CASEDATABASE";
+        await CreateDatabase(db);
+
+        // Check that the database has been created
+        IEnumerable<string> databasesBeforeMigration = await GetDatabases();
+        databasesBeforeMigration.Should().Contain(db);
+
+        await using var migrator = GetMigrator(GetConfiguration(db.ToLower(), true)); // ToLower is important here, this reproduces the bug in #167
+        // There should be no errors running the migration
+        Assert.DoesNotThrowAsync(() => migrator.Migrate());
+    }
+
 }

--- a/grate.unittests/SqlServerCaseSensitive/Database.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Database.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class Database : Generic.GenericDatabase
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/DockerContainer.cs
+++ b/grate.unittests/SqlServerCaseSensitive/DockerContainer.cs
@@ -1,0 +1,12 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class DockerContainer : Generic.GenericDockerContainer
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/MigrationTables.cs
+++ b/grate.unittests/SqlServerCaseSensitive/MigrationTables.cs
@@ -1,0 +1,12 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class MigrationTables : Generic.GenericMigrationTables
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Anytime_scripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Anytime_scripts.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class Anytime_scripts : Generic.Running_MigrationScripts.Anytime_scripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/DropDatabase.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/DropDatabase.cs
@@ -1,0 +1,12 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class DropDatabase : Generic.Running_MigrationScripts.DropDatabase
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Environment_scripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Environment_scripts.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class Environment_scripts : Generic.Running_MigrationScripts.Environment_scripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Everytime_scripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Everytime_scripts.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class Everytime_scripts : Generic.Running_MigrationScripts.Everytime_scripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Failing_Scripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Failing_Scripts.cs
@@ -1,0 +1,14 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class Failing_Scripts : Generic.Running_MigrationScripts.Failing_Scripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+        protected override string ExpectedErrorMessageForInvalidSql => "Incorrect syntax near 'TOP'.";
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/One_time_scripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/One_time_scripts.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class One_time_scripts : Generic.Running_MigrationScripts.One_time_scripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Order_Of_Scripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Order_Of_Scripts.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class Order_Of_Scripts : Generic.Running_MigrationScripts.Order_Of_Scripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/RestoreDatabase.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/RestoreDatabase.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
+using FluentAssertions;
+using grate.Configuration;
+using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class RestoreDatabase : SqlServerScriptsBase
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+        private readonly string _backupPath = "/var/opt/mssql/backup/test.bak";
+
+        [OneTimeSetUp]
+        public async Task RunBeforeTest()
+        {
+            await using (var conn = Context.CreateDbConnection("master"))
+            {
+                await conn.ExecuteAsync("use [master] CREATE DATABASE [test]");
+                await conn.ExecuteAsync("use [test] CREATE TABLE dbo.Table_1 (column1 int NULL)");
+                await conn.ExecuteAsync($"BACKUP DATABASE [test] TO  DISK = '{_backupPath}'");
+                await conn.ExecuteAsync("use [master] DROP DATABASE [test]");
+            }
+        }
+
+        [Test]
+        public async Task Ensure_database_gets_restored()
+        {
+            var db = TestConfig.RandomDatabase();
+
+            var parent = CreateRandomTempDirectory();
+            var knownFolders = FoldersConfiguration.Default(null);
+            CreateDummySql(parent, knownFolders[KnownFolderKeys.Sprocs]);
+
+            var restoreConfig = Context.GetConfiguration(db, parent, knownFolders) with
+            {
+                Restore = _backupPath
+            };
+
+            await using (var migrator = Context.GetMigrator(restoreConfig))
+            {
+                await migrator.Migrate();
+            }
+
+            int[] results;
+            string sql = $"select count(1) from sys.tables where [name]='Table_1'";
+
+            await using (var conn = Context.CreateDbConnection(db))
+            {
+                results = (await conn.QueryAsync<int>(sql)).ToArray();
+            }
+
+            results.First().Should().Be(1);
+        }
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/ScriptsRun_Table.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/ScriptsRun_Table.cs
@@ -1,0 +1,9 @@
+﻿using grate.unittests.TestInfrastructure;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    public class ScriptsRun_Table : Generic.Running_MigrationScripts.ScriptsRun_Table
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/SqlServerScriptsBase.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/SqlServerScriptsBase.cs
@@ -1,0 +1,8 @@
+﻿using grate.unittests.Generic.Running_MigrationScripts;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    public abstract class SqlServerScriptsBase : MigrationsScriptsBase
+    {
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/TokenScripts.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/TokenScripts.cs
@@ -1,0 +1,12 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class TokenScripts : Generic.Running_MigrationScripts.TokenScripts
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Versioning_The_Database.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/Versioning_The_Database.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
+{
+    [TestFixture]
+    [Category("SqlServerCaseSensitive")]
+    // ReSharper disable once InconsistentNaming
+    public class Versioning_The_Database : Generic.Running_MigrationScripts.Versioning_The_Database
+    {
+        protected override IGrateTestContext Context => GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/SqlServerCaseSensitive/SetupTestEnvironment.cs
+++ b/grate.unittests/SqlServerCaseSensitive/SetupTestEnvironment.cs
@@ -1,0 +1,13 @@
+﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+namespace grate.unittests.SqlServerCaseSensitive
+{
+    [SetUpFixture]
+    [Category("SqlServerCaseSensitive")]
+    public class SetupTestEnvironment : Generic.SetupDockerTestEnvironment
+    {
+        protected override IGrateTestContext GrateTestContext => unittests.GrateTestContext.SqlServerCaseSensitive;
+        protected override IDockerTestContext DockerTestContext => unittests.GrateTestContext.SqlServerCaseSensitive;
+    }
+}

--- a/grate.unittests/TestContext.cs
+++ b/grate.unittests/TestContext.cs
@@ -5,6 +5,7 @@ namespace grate.unittests;
 public static class GrateTestContext
 {
     internal static readonly SqlServerGrateTestContext SqlServer = new();
+    internal static readonly SqlServerGrateTestContext SqlServerCaseSensitive = new("Latin1_General_CS_AS"); //CS == Case Sensitive
     internal static readonly OracleGrateTestContext Oracle = new();
     internal static readonly PostgreSqlGrateTestContext PostgreSql = new();
     // ReSharper disable once InconsistentNaming

--- a/grate.unittests/TestInfrastructure/SqlServerGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/SqlServerGrateTestContext.cs
@@ -12,6 +12,13 @@ namespace grate.unittests.TestInfrastructure;
 
 class SqlServerGrateTestContext : TestContextBase, IGrateTestContext, IDockerTestContext
 {
+
+
+    public SqlServerGrateTestContext(string serverCollation) => ServerCollation = serverCollation;
+
+    public SqlServerGrateTestContext(): this("Danish_Norwegian_CI_AS")
+    {}
+
     public string AdminPassword { get; set; } = default!;
     public int? Port { get; set; }
     public override int? ContainerPort => 1433;
@@ -25,7 +32,7 @@ class SqlServerGrateTestContext : TestContextBase, IGrateTestContext, IDockerTes
     };
 
     public string DockerCommand(string serverName, string adminPassword) =>
-        $"run -d --name {serverName} -e ACCEPT_EULA=Y -e SA_PASSWORD={adminPassword} -e MSSQL_PID=Developer -e MSSQL_COLLATION=Danish_Norwegian_CI_AS -P {DockerImage}";
+        $"run -d --name {serverName} -e ACCEPT_EULA=Y -e SA_PASSWORD={adminPassword} -e MSSQL_PID=Developer -e MSSQL_COLLATION={ServerCollation} -P {DockerImage}";
 
     public string AdminConnectionString => $"Data Source=localhost,{Port};Initial Catalog=master;User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
     public string ConnectionString(string database) => $"Data Source=localhost,{Port};Initial Catalog={database};User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
@@ -57,4 +64,6 @@ class SqlServerGrateTestContext : TestContextBase, IGrateTestContext, IDockerTes
     };
     
     public bool SupportsCreateDatabase => true;
+
+    public string ServerCollation { get; }
 }

--- a/grate/Migration/AnsiSqlDatabase.cs
+++ b/grate/Migration/AnsiSqlDatabase.cs
@@ -254,7 +254,7 @@ public abstract class AnsiSqlDatabase : IDatabase
 
     private async Task<bool> RunSchemaExists()
     {
-        string sql = $"SELECT s.schema_name FROM information_schema.schemata s WHERE s.schema_name = '{SchemaName}'";
+        string sql = $"SELECT s.SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA s WHERE s.SCHEMA_NAME = '{SchemaName}'";
         var res = await ExecuteScalarAsync<string>(ActiveConnection, sql);
         return res == SchemaName;
     }
@@ -366,21 +366,21 @@ CREATE TABLE {VersionTable}(
     protected virtual string ExistsSql(string tableSchema, string fullTableName)
     {
         return $@"
-SELECT * FROM information_schema.tables 
+SELECT * FROM INFORMATION_SCHEMA.TABLES 
 WHERE 
-table_schema = '{tableSchema}' AND
-table_name = '{fullTableName}'
+TABLE_SCHEMA = '{tableSchema}' AND
+TABLE_NAME = '{fullTableName}'
 ";
     }
 
     protected virtual string ExistsSql(string tableSchema, string fullTableName, string columnName)
     {
         return $@"
-SELECT * FROM information_schema.columns 
+SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
 WHERE 
-table_schema = '{tableSchema}' AND
-table_name = '{fullTableName}' AND
-column_name = '{columnName}' 
+TABLE_SCHEMA = '{tableSchema}' AND
+TABLE_NAME = '{fullTableName}' AND
+COLUMN_NAME = '{columnName}' 
 ";
     }
 


### PR DESCRIPTION
A very early mentor of mine taught me to not write new features while I had outstanding bugs.

In that light, I spent some time when I was sitting on a plane last night adding a copy of the tests that targets a **case-sensitive** Sql Server, and made a couple of small changes to get those tests to pass.

The only thing that needed changing to get the existing tests green was correcting the case of `INFORMATION_SCHEMA` and it's columns.

This obviously doesn't address all the casing issues we have currently, but it's a step in the right direction.

