### PR TITLE
Solve #245 without new command-line parameter

### DIFF
--- a/grate.unittests/Generic/GenericMigrationTables.cs
+++ b/grate.unittests/Generic/GenericMigrationTables.cs
@@ -120,9 +120,7 @@ public abstract class GenericMigrationTables
         await CheckTableCasing("ScriptsRunErrors", existingTable, (config, name) => config.ScriptsRunErrorsTableName = name);
     }
     
-
-
-    private async Task CheckTableCasing(string tableName, string funnyCasing, Action<GrateConfiguration, string> setTableName)
+    protected virtual async Task CheckTableCasing(string tableName, string funnyCasing, Action<GrateConfiguration, string> setTableName)
     {
         var db = TestConfig.RandomDatabase();
 

--- a/grate.unittests/Generic/GenericMigrationTables.cs
+++ b/grate.unittests/Generic/GenericMigrationTables.cs
@@ -242,7 +242,7 @@ public abstract class GenericMigrationTables
     protected virtual string CountTableSql(string schemaName, string tableName)
     {
         return $@"
-SELECT count(table_name) FROM information_schema.tables 
+SELECT count(table_name) FROM INFORMATION_SCHEMA.tables
 WHERE 
 table_schema = '{schemaName}' AND
 table_name = '{tableName}'

--- a/grate.unittests/Generic/GenericMigrationTables.cs
+++ b/grate.unittests/Generic/GenericMigrationTables.cs
@@ -242,7 +242,7 @@ public abstract class GenericMigrationTables
     protected virtual string CountTableSql(string schemaName, string tableName)
     {
         return $@"
-SELECT count(table_name) FROM INFORMATION_SCHEMA.tables
+SELECT count(table_name) FROM INFORMATION_SCHEMA.TABLES
 WHERE 
 table_schema = '{schemaName}' AND
 table_name = '{tableName}'

--- a/grate.unittests/Oracle/MigrationTables.cs
+++ b/grate.unittests/Oracle/MigrationTables.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading.Tasks;
+using grate.Configuration;
 using grate.unittests.TestInfrastructure;
 using NUnit.Framework;
 
@@ -8,6 +11,12 @@ namespace grate.unittests.Oracle;
 public class MigrationTables : Generic.GenericMigrationTables
 {
     protected override IGrateTestContext Context => GrateTestContext.Oracle;
+
+    protected override Task CheckTableCasing(string tableName, string funnyCasing, Action<GrateConfiguration, string> setTableName)
+    {
+        Assert.Ignore("Oracle has never been case-sensitive for grate. No need to introduce that now.");
+        return Task.CompletedTask;
+    }
 
     protected override string CountTableSql(string schemaName, string tableName)
     {

--- a/grate.unittests/Oracle/MigrationTables.cs
+++ b/grate.unittests/Oracle/MigrationTables.cs
@@ -5,7 +5,15 @@ namespace grate.unittests.Oracle;
 
 [TestFixture]
 [Category("Oracle")]
-public class MigrationTables: Generic.GenericMigrationTables
+public class MigrationTables : Generic.GenericMigrationTables
 {
     protected override IGrateTestContext Context => GrateTestContext.Oracle;
+
+    protected override string CountTableSql(string schemaName, string tableName)
+    {
+        return $@"
+SELECT COUNT(table_name) FROM user_tables
+WHERE 
+lower(table_name) = '{tableName.ToLowerInvariant()}'";
+    }
 }

--- a/grate.unittests/SqLite/MigrationTables.cs
+++ b/grate.unittests/SqLite/MigrationTables.cs
@@ -8,4 +8,13 @@ namespace grate.unittests.Sqlite;
 public class MigrationTables: Generic.GenericMigrationTables
 {
     protected override IGrateTestContext Context => GrateTestContext.Sqlite;
+
+    protected override string CountTableSql(string schemaName, string tableName)
+    {
+        return $@"
+SELECT COUNT(name) FROM sqlite_master 
+WHERE type ='table' AND 
+name = '{tableName}';
+";
+    }
 }

--- a/grate.unittests/SqlServer/MigrationTables.cs
+++ b/grate.unittests/SqlServer/MigrationTables.cs
@@ -8,4 +8,14 @@ namespace grate.unittests.SqlServer;
 public class MigrationTables: Generic.GenericMigrationTables
 {
     protected override IGrateTestContext Context => GrateTestContext.SqlServer;
+    
+    protected override string CountTableSql(string schemaName, string tableName)
+    {
+        return $@"
+SELECT count(table_name) FROM information_schema.tables
+WHERE
+table_schema = '{schemaName}' AND
+table_name = '{tableName}' COLLATE Latin1_General_CS_AS
+";
+    }
 }

--- a/grate.unittests/SqlServer/MigrationTables.cs
+++ b/grate.unittests/SqlServer/MigrationTables.cs
@@ -12,7 +12,7 @@ public class MigrationTables: Generic.GenericMigrationTables
     protected override string CountTableSql(string schemaName, string tableName)
     {
         return $@"
-SELECT count(table_name) FROM INFORMATION_SCHEMA.tables
+SELECT count(table_name) FROM INFORMATION_SCHEMA.TABLES
 WHERE
 TABLE_SCHEMA = '{schemaName}' AND
 TABLE_NAME = '{tableName}' COLLATE Latin1_General_CS_AS

--- a/grate.unittests/SqlServer/MigrationTables.cs
+++ b/grate.unittests/SqlServer/MigrationTables.cs
@@ -12,10 +12,10 @@ public class MigrationTables: Generic.GenericMigrationTables
     protected override string CountTableSql(string schemaName, string tableName)
     {
         return $@"
-SELECT count(table_name) FROM information_schema.tables
+SELECT count(table_name) FROM INFORMATION_SCHEMA.tables
 WHERE
-table_schema = '{schemaName}' AND
-table_name = '{tableName}' COLLATE Latin1_General_CS_AS
+TABLE_SCHEMA = '{schemaName}' AND
+TABLE_NAME = '{tableName}' COLLATE Latin1_General_CS_AS
 ";
     }
 }

--- a/grate.unittests/TestContext.cs
+++ b/grate.unittests/TestContext.cs
@@ -1,4 +1,8 @@
 ﻿using grate.unittests.TestInfrastructure;
+using NUnit.Framework;
+
+// There are some parallelism issues, but this does not solve it
+//[assembly:LevelOfParallelism(1)]
 
 namespace grate.unittests;
 

--- a/grate.unittests/TestInfrastructure/IGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/IGrateTestContext.cs
@@ -56,6 +56,17 @@ public interface IGrateTestContext
             SqlFilesDirectory = sqlFilesDirectory
         };
 
+    public GrateConfiguration GetConfiguration(string databaseName, DirectoryInfo sqlFilesDirectory,
+        IFoldersConfiguration knownFolders, string? env, bool runInTransaction) =>
+        DefaultConfiguration with
+        {
+            ConnectionString = ConnectionString(databaseName),
+            Folders = knownFolders,
+            Environment = env != null ? new GrateEnvironment(env) : null,
+            Transaction = runInTransaction,
+            SqlFilesDirectory = sqlFilesDirectory
+        };
+
     public GrateMigrator GetMigrator(GrateConfiguration config)
     {
         var factory = Substitute.For<IFactory>();

--- a/grate/Configuration/GrateConfiguration.cs
+++ b/grate/Configuration/GrateConfiguration.cs
@@ -26,6 +26,10 @@ public record GrateConfiguration
     public string? ConnectionString { get; init; } = null;
 
     public string SchemaName { get; init; } = "grate";
+    
+    public string ScriptsRunTableName { get; set; } = "ScriptsRun";
+    public string ScriptsRunErrorsTableName { get; set; } = "ScriptsRunErrors";
+    public string VersionTableName { get; set; } = "Version";
 
     public string? AdminConnectionString
     {

--- a/grate/Migration/AnsiSqlDatabase.cs
+++ b/grate/Migration/AnsiSqlDatabase.cs
@@ -59,7 +59,7 @@ public abstract class AnsiSqlDatabase : IDatabase
     private string ScriptsRunErrorsTableName { get; set; }
     private string VersionTableName { get; set; }
 
-    public virtual async Task InitializeConnections(GrateConfiguration configuration)
+    public virtual Task InitializeConnections(GrateConfiguration configuration)
     {
         Logger.LogInformation("Initializing connections.");
 
@@ -73,6 +73,8 @@ public abstract class AnsiSqlDatabase : IDatabase
         ScriptsRunErrorsTableName = configuration.ScriptsRunErrorsTableName;
         
         Config = configuration;
+        
+        return Task.CompletedTask;
     }
 
     private async Task<string> ExistingOrDefault(string schemaName, string tableName) =>
@@ -281,6 +283,7 @@ public abstract class AnsiSqlDatabase : IDatabase
     protected virtual async Task CreateScriptsRunTable()
     {
         // Update scripts run table name with the correct casing, should it differ from the standard
+        
         ScriptsRunTableName = await ExistingOrDefault(SchemaName, ScriptsRunTableName);
         
         string createSql = $@"
@@ -373,7 +376,6 @@ CREATE TABLE {VersionTable}(
         var fullTableName = SupportsSchemas ? tableName : _syntax.TableWithSchema(schemaName, tableName);
         var tableSchema = SupportsSchemas ? schemaName : DatabaseName;
         
-
         string existsSql = ExistsSql(tableSchema, fullTableName);
 
         var res = await ExecuteScalarAsync<object>(ActiveConnection, existsSql);

--- a/grate/Migration/AnsiSqlDatabase.cs
+++ b/grate/Migration/AnsiSqlDatabase.cs
@@ -46,25 +46,39 @@ public abstract class AnsiSqlDatabase : IDatabase
         .Split("=", TrimEntries | RemoveEmptyEntries).Last();
 
     public abstract bool SupportsDdlTransactions { get; }
-    protected abstract bool SupportsSchemas { get; }
+    public abstract bool SupportsSchemas { get; }
     public bool SplitBatchStatements => true;
 
     public string StatementSeparatorRegex => _syntax.StatementSeparatorRegex;
 
-    public string ScriptsRunTable => _syntax.TableWithSchema(SchemaName, "ScriptsRun");
-    public string ScriptsRunErrorsTable => _syntax.TableWithSchema(SchemaName, "ScriptsRunErrors");
-    public string VersionTable => _syntax.TableWithSchema(SchemaName, "Version");
+    public string ScriptsRunTable => _syntax.TableWithSchema(SchemaName, ScriptsRunTableName);
+    public string ScriptsRunErrorsTable => _syntax.TableWithSchema(SchemaName, ScriptsRunErrorsTableName);
+    public string VersionTable => _syntax.TableWithSchema(SchemaName, VersionTableName);
 
-    public virtual Task InitializeConnections(GrateConfiguration configuration)
+    private string ScriptsRunTableName { get; set; }
+    private string ScriptsRunErrorsTableName { get; set; }
+    private string VersionTableName { get; set; }
+
+    public virtual async Task InitializeConnections(GrateConfiguration configuration)
     {
         Logger.LogInformation("Initializing connections.");
 
         ConnectionString = configuration.ConnectionString;
         AdminConnectionString = configuration.AdminConnectionString;
+        
         SchemaName = configuration.SchemaName;
+
+        VersionTableName = configuration.VersionTableName;
+        ScriptsRunTableName = configuration.ScriptsRunTableName;
+        ScriptsRunErrorsTableName = configuration.ScriptsRunErrorsTableName;
+        
         Config = configuration;
-        return Task.CompletedTask;
     }
+
+    private async Task<string> ExistingOrDefault(string schemaName, string tableName) =>
+        await ExistingTable(schemaName, tableName) ?? tableName;
+    
+        
 
     private string? AdminConnectionString { get; set; }
     protected string? ConnectionString { get; set; }
@@ -266,6 +280,9 @@ public abstract class AnsiSqlDatabase : IDatabase
 
     protected virtual async Task CreateScriptsRunTable()
     {
+        // Update scripts run table name with the correct casing, should it differ from the standard
+        ScriptsRunTableName = await ExistingOrDefault(SchemaName, ScriptsRunTableName);
+        
         string createSql = $@"
 CREATE TABLE {ScriptsRunTable}(
 	{_syntax.PrimaryKeyColumn("id")},
@@ -288,6 +305,9 @@ CREATE TABLE {ScriptsRunTable}(
 
     protected virtual async Task CreateScriptsRunErrorsTable()
     {
+        // Update scripts run errors table name with the correct casing, should it differ from the standard
+        ScriptsRunErrorsTableName = await ExistingOrDefault(SchemaName, ScriptsRunErrorsTableName);
+        
         string createSql = $@"
 CREATE TABLE {ScriptsRunErrorsTable}(
 	{_syntax.PrimaryKeyColumn("id")},
@@ -310,6 +330,9 @@ CREATE TABLE {ScriptsRunErrorsTable}(
 
     protected virtual async Task CreateVersionTable()
     {
+        // Update version table name with the correct casing, should it differ from the standard
+        VersionTableName = await ExistingOrDefault(SchemaName, VersionTableName);
+        
         string createSql = $@"
 CREATE TABLE {VersionTable}(
 	{_syntax.PrimaryKeyColumn("id")},
@@ -320,6 +343,7 @@ CREATE TABLE {VersionTable}(
 	entered_by {_syntax.VarcharType}(50) NULL
 	{_syntax.PrimaryKeyConstraint("Version", "id")}
 )";
+        
         if (!await VersionTableExists())
         {
             await ExecuteNonQuery(ActiveConnection, createSql, Config?.CommandTimeout);
@@ -338,21 +362,26 @@ CREATE TABLE {VersionTable}(
         }
     }
 
-    protected async Task<bool> ScriptsRunTableExists() => await TableExists(SchemaName, "ScriptsRun");
-    protected async Task<bool> ScriptsRunErrorsTableExists() => await TableExists(SchemaName, "ScriptsRunErrors");
-    public async Task<bool> VersionTableExists() => await TableExists(SchemaName, "Version");
-    protected async Task<bool> StatusColumnInVersionTableExists() => await ColumnExists(SchemaName, "Version", "status");
+    protected async Task<bool> ScriptsRunTableExists() => (await ExistingTable(SchemaName, ScriptsRunTableName) is not null) ;
+    protected async Task<bool> ScriptsRunErrorsTableExists() => (await ExistingTable(SchemaName, ScriptsRunErrorsTableName) is not null);
+    public async Task<bool> VersionTableExists() => (await ExistingTable(SchemaName, VersionTableName) is not null);
+    
+    protected async Task<bool> StatusColumnInVersionTableExists() => await ColumnExists(SchemaName, VersionTableName, "status");
 
-    public async Task<bool> TableExists(string schemaName, string tableName)
+    public async Task<string?> ExistingTable(string schemaName, string tableName)
     {
         var fullTableName = SupportsSchemas ? tableName : _syntax.TableWithSchema(schemaName, tableName);
         var tableSchema = SupportsSchemas ? schemaName : DatabaseName;
+        
 
         string existsSql = ExistsSql(tableSchema, fullTableName);
 
         var res = await ExecuteScalarAsync<object>(ActiveConnection, existsSql);
         
-        return !DBNull.Value.Equals(res) && res is not null;
+        var name = (!DBNull.Value.Equals(res) && res is not null) ? (string) res : null;
+        
+        var prefix = SupportsSchemas ? string.Empty : _syntax.TableWithSchema(schemaName, string.Empty);
+        return name?[prefix.Length..] ;
     }
 
     private async Task<bool> ColumnExists(string schemaName, string tableName, string columnName)
@@ -369,10 +398,10 @@ CREATE TABLE {VersionTable}(
     protected virtual string ExistsSql(string tableSchema, string fullTableName)
     {
         return $@"
-SELECT * FROM INFORMATION_SCHEMA.TABLES 
+SELECT table_name FROM INFORMATION_SCHEMA.TABLES 
 WHERE 
-TABLE_SCHEMA = '{tableSchema}' AND
-TABLE_NAME = '{fullTableName}'
+LOWER(TABLE_SCHEMA) = LOWER('{tableSchema}') AND
+LOWER(TABLE_NAME) = LOWER('{fullTableName}')
 ";
     }
 
@@ -381,9 +410,9 @@ TABLE_NAME = '{fullTableName}'
         return $@"
 SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
 WHERE 
-TABLE_SCHEMA = '{tableSchema}' AND
-TABLE_NAME = '{fullTableName}' AND
-COLUMN_NAME = '{columnName}' 
+LOWER(TABLE_SCHEMA) = LOWER('{tableSchema}') AND
+LOWER(TABLE_NAME) = LOWER('{fullTableName}') AND
+LOWER(COLUMN_NAME) = LOWER('{columnName}') 
 ";
     }
 

--- a/grate/Migration/IDatabase.cs
+++ b/grate/Migration/IDatabase.cs
@@ -17,6 +17,7 @@ public interface IDatabase : IAsyncDisposable
     public string ScriptsRunErrorsTable { get; }
     public string VersionTable { get; }
     DbConnection ActiveConnection { set; }
+    bool SupportsSchemas { get; }
 
     Task InitializeConnections(GrateConfiguration configuration);
     Task OpenConnection();
@@ -48,4 +49,5 @@ public interface IDatabase : IAsyncDisposable
     void SetDefaultConnectionActive();
     Task<IDisposable> OpenNewActiveConnection();
     Task OpenActiveConnection();
+    Task<string?> ExistingTable(string schemaName, string tableName);
 }

--- a/grate/Migration/MariaDbDatabase.cs
+++ b/grate/Migration/MariaDbDatabase.cs
@@ -15,7 +15,7 @@ public class MariaDbDatabase : AnsiSqlDatabase
     { }
 
     public override bool SupportsDdlTransactions => false;
-    protected override bool SupportsSchemas => false;
+    public override bool SupportsSchemas => false;
     protected override DbConnection GetSqlConnection(string? connectionString) => new MySqlConnection(connectionString);
 
     public override Task RestoreDatabase(string backupPath)

--- a/grate/Migration/OracleDatabase.cs
+++ b/grate/Migration/OracleDatabase.cs
@@ -23,13 +23,13 @@ public class OracleDatabase : AnsiSqlDatabase
     }
 
     public override bool SupportsDdlTransactions => false;
-    protected override bool SupportsSchemas => false;
+    public override bool SupportsSchemas => false;
 
     protected override DbConnection GetSqlConnection(string? connectionString) => new OracleConnection(connectionString);
 
     protected override string ExistsSql(string tableSchema, string fullTableName) =>
         $@"
-SELECT * FROM user_tables
+SELECT table_name FROM user_tables
 WHERE 
 lower(table_name) = '{fullTableName.ToLowerInvariant()}'
 ";

--- a/grate/Migration/PostgreSqlDatabase.cs
+++ b/grate/Migration/PostgreSqlDatabase.cs
@@ -13,7 +13,7 @@ public class PostgreSqlDatabase : AnsiSqlDatabase
     { }
 
     public override bool SupportsDdlTransactions => true;
-    protected override bool SupportsSchemas => true;
+    public override bool SupportsSchemas => true;
     protected override DbConnection GetSqlConnection(string? connectionString) => new NpgsqlConnection(connectionString);
 
     public override Task RestoreDatabase(string backupPath)

--- a/grate/Migration/SqLiteDatabase.cs
+++ b/grate/Migration/SqLiteDatabase.cs
@@ -17,14 +17,14 @@ public class SqliteDatabase : AnsiSqlDatabase
     { }
 
     public override bool SupportsDdlTransactions => false;
-    protected override bool SupportsSchemas => false;
+    public override bool SupportsSchemas => false;
     protected override DbConnection GetSqlConnection(string? connectionString) => new SqliteConnection(connectionString);
 
     protected override string ExistsSql(string tableSchema, string fullTableName) =>
         $@"
 SELECT name FROM sqlite_master 
 WHERE type ='table' AND 
-name = '{fullTableName}';
+LOWER(name) = LOWER('{fullTableName}');
 ";
 
     protected override string ExistsSql(string tableSchema, string fullTableName, string columnName) =>

--- a/grate/Migration/SqlServerDatabase.cs
+++ b/grate/Migration/SqlServerDatabase.cs
@@ -16,7 +16,7 @@ public class SqlServerDatabase : AnsiSqlDatabase
     { }
 
     public override bool SupportsDdlTransactions => true;
-    protected override bool SupportsSchemas => true;
+    public override bool SupportsSchemas => true;
     protected override DbConnection GetSqlConnection(string? connectionString)
     {
         // If pooling is not explicitly mentioned in the connection string, turn it off, as enabling it


### PR DESCRIPTION
Be a bit forgiving on the casing of any already-existing `Version`, `ScriptsRun` and `ScriptsRunErrors` tables, to be more backwards-compatible with RoundhousE, which used lower-case table names for some databases