### PR TITLE
Feat/252 custom create database

### DIFF
--- a/docs/ConfigurationOptions/FolderConfiguration.md
+++ b/docs/ConfigurationOptions/FolderConfiguration.md
@@ -131,6 +131,8 @@ grate processes the files in a standard set of directories in a fixed order for 
 
 | Folder | Script type | Explanation |
 | ------ | ------- |------- |
+| <nobr> (-1. dropDatabase)</nobr> | Anytime scripts | If you have the need for a custom `DROP DATABASE` script (used with the `--drop` command-line flag) |
+| <nobr> (0. createDatabase)</nobr> | Anytime scripts | If you have the need for a custom `CREATE DATABASE` script, put it here, and it will be used instead of the default. |
 | <nobr> 1. beforeMigration</nobr> | Everytime scripts | If you have particular tasks you want to perform prior to any database migrations (custom logging? database backups? disable replication?) you can do it here. |
 | <nobr>2. alterDatabase</nobr> | Anytime scripts | If you have scripts that need to alter the database config itself (rather than the _contents_ of the database) thjis is the place to do it.  For example setting recovery modes, enabling query stores, etc etc |
 | <nobr>3. runAfterCreateDatabase</nobr> | Anytime scripts | This directory is only processed if the database was created from scratch by grate.  Maybe you need to add user accounts or similar?

--- a/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_CustomNames.cs
+++ b/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_CustomNames.cs
@@ -69,6 +69,7 @@ public class KnownFolders_CustomNames
     private static readonly IKnownFolderNames OverriddenFolderNames = new KnownFolderNames()
     {
         BeforeMigration = "beforeMigration" + Random.GetString(8),
+        CreateDatabase = "createDatabase" + Random.GetString(8),
         AlterDatabase = "alterDatabase" + Random.GetString(8),
         RunAfterCreateDatabase = "runAfterCreateDatabase" + Random.GetString(8),
         RunBeforeUp = "runBeforeUp" + Random.GetString(8),

--- a/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_Default.cs
+++ b/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_Default.cs
@@ -45,12 +45,12 @@ public class KnownFolders_Default
     [Test]
     [TestCaseSource(nameof(ExpectedKnownFolderNames))]
     public void Has_expected_folder_configuration(
-            MigrationsFolder folder, 
-            string expectedName, 
-            MigrationType expectedType,
-            ConnectionType expectedConnectionType,
-            TransactionHandling transactionHandling
-        )
+        MigrationsFolder folder, 
+        string expectedName, 
+        MigrationType expectedType,
+        ConnectionType expectedConnectionType,
+        TransactionHandling transactionHandling
+    )
     {
         var root = Root.ToString();
         
@@ -94,11 +94,11 @@ public class KnownFolders_Default
     ) =>
         new TestCaseData(folder, expectedName, expectedType, expectedConnectionType, transactionHandling)
             .SetArgDisplayNames(
-                    migrationsFolderDefinitionName, 
-                    expectedName,
-                    expectedType.ToString(),
-                    "conn: " + expectedConnectionType,
-                    "tran: " + transactionHandling
-                );
+                migrationsFolderDefinitionName, 
+                expectedName,
+                expectedType.ToString(),
+                "conn: " + expectedConnectionType,
+                "tran: " + transactionHandling
+            );
    
 }

--- a/grate.unittests/Generic/GenericDatabase.cs
+++ b/grate.unittests/Generic/GenericDatabase.cs
@@ -60,8 +60,9 @@ public abstract class GenericDatabase
         File.Delete(Path.Join(Wrap(config.SqlFilesDirectory, config.Folders?.CreateDatabase?.Path).ToString(), "createDatabase.sql"));
     
         // The database should have been created by the custom script
-        IEnumerable<string> databases = await GetDatabases();
+        IEnumerable<string> databases = (await GetDatabases()).ToList();
         databases.Should().Contain(scriptedDatabase);
+        databases.Should().NotContain(confedDatabase);
     }
 
     [Test]

--- a/grate.unittests/Generic/GenericDatabase.cs
+++ b/grate.unittests/Generic/GenericDatabase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data.Common;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -8,7 +9,9 @@ using FluentAssertions;
 using grate.Configuration;
 using grate.Migration;
 using grate.unittests.TestInfrastructure;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
+using static System.StringSplitOptions;
 
 namespace grate.unittests.Generic;
 
@@ -27,6 +30,38 @@ public abstract class GenericDatabase
 
         IEnumerable<string> databases = await GetDatabases();
         databases.Should().Contain(db);
+    }
+    
+    [Test]
+    public virtual async Task Is_created_with_custom_script_if_custom_create_database_folder_exists()
+    {
+        var scriptedDatabase = "CUSTOMSCRIPTEDDATABASE";
+        var confedDatabase = "DEFAULTDATABASE";
+    
+        var config = GetConfiguration(confedDatabase, true);
+        var password = Context.AdminConnectionString
+            .Split(";", TrimEntries | RemoveEmptyEntries)
+            .SingleOrDefault(entry => entry.StartsWith("Password") || entry.StartsWith("Pwd"))?
+            .Split("=", TrimEntries | RemoveEmptyEntries)
+            .Last();
+    
+        var customScript = Context.Syntax.CreateDatabase(scriptedDatabase, password);
+        TestConfig.WriteContent(Wrap(config.SqlFilesDirectory, config.Folders?.CreateDatabase?.Path), "createDatabase.sql", customScript);
+        try
+        {
+            await using var migrator = GetMigrator(config);
+            await migrator.Migrate();
+        }
+        catch (DbException)
+        {
+            //Do nothing because database name is wrong due to custom script
+        }
+        
+        File.Delete(Path.Join(Wrap(config.SqlFilesDirectory, config.Folders?.CreateDatabase.Path).ToString(), "createDatabase.sql"));
+    
+        // The database should have been created by the custom script
+        IEnumerable<string> databases = await GetDatabases();
+        databases.Should().Contain(scriptedDatabase);
     }
 
     [Test]
@@ -179,5 +214,9 @@ public abstract class GenericDatabase
             SqlFilesDirectory = parent
         };
     }
+    
+    
+    protected static DirectoryInfo Wrap(DirectoryInfo root, string? subFolder) =>
+        new DirectoryInfo(Path.Combine(root.ToString(), subFolder ?? ""));
     
 }

--- a/grate.unittests/Generic/GenericDatabase.cs
+++ b/grate.unittests/Generic/GenericDatabase.cs
@@ -57,7 +57,7 @@ public abstract class GenericDatabase
             //Do nothing because database name is wrong due to custom script
         }
         
-        File.Delete(Path.Join(Wrap(config.SqlFilesDirectory, config.Folders?.CreateDatabase.Path).ToString(), "createDatabase.sql"));
+        File.Delete(Path.Join(Wrap(config.SqlFilesDirectory, config.Folders?.CreateDatabase?.Path).ToString(), "createDatabase.sql"));
     
         // The database should have been created by the custom script
         IEnumerable<string> databases = await GetDatabases();

--- a/grate.unittests/SqLite/Database.cs
+++ b/grate.unittests/SqLite/Database.cs
@@ -42,5 +42,9 @@ public class Database: Generic.GenericDatabase
         return await ValueTask.FromResult(dbNames);
     }
 
+    [Ignore("SQLite does not support custom database creation script")]
+    public override Task Is_created_with_custom_script_if_custom_create_database_folder_exists() =>
+        Task.CompletedTask;
+
     protected override bool ThrowOnMissingDatabase => false;
 }

--- a/grate/Configuration/FoldersConfiguration.cs
+++ b/grate/Configuration/FoldersConfiguration.cs
@@ -23,15 +23,17 @@ public class FoldersConfiguration: Dictionary<string, MigrationsFolder?>, IFolde
     
     public FoldersConfiguration() 
     { }
-
+    
+    public MigrationsFolder? CreateDatabase { get; set; }
+    public MigrationsFolder? DropDatabase { get; set; }
 
     public static FoldersConfiguration Empty => new();
     
     public static IFoldersConfiguration Default(IKnownFolderNames? folderNames = null)
     {
         folderNames ??= KnownFolderNames.Default;
-        
-        return new FoldersConfiguration()
+
+        var foldersConfiguration = new FoldersConfiguration()
         {
             { KnownFolderKeys.BeforeMigration, new MigrationsFolder("BeforeMigration", folderNames.BeforeMigration, EveryTime, TransactionHandling: TransactionHandling.Autonomous) },
             { KnownFolderKeys.AlterDatabase , new MigrationsFolder("AlterDatabase", folderNames.AlterDatabase, AnyTime, ConnectionType.Admin, TransactionHandling.Autonomous) },
@@ -46,8 +48,12 @@ public class FoldersConfiguration: Dictionary<string, MigrationsFolder?>, IFolde
             { KnownFolderKeys.Indexes, new MigrationsFolder("Indexes", folderNames.Indexes, AnyTime) },
             { KnownFolderKeys.RunAfterOtherAnyTimeScripts, new MigrationsFolder("Run after Other Anytime Scripts", folderNames.RunAfterOtherAnyTimeScripts, AnyTime) },
             { KnownFolderKeys.Permissions, new MigrationsFolder("Permissions", folderNames.Permissions, EveryTime, TransactionHandling: TransactionHandling.Autonomous) },
-            { KnownFolderKeys.AfterMigration, new MigrationsFolder("AfterMigration", folderNames.AfterMigration, EveryTime, TransactionHandling: TransactionHandling.Autonomous) }
+            { KnownFolderKeys.AfterMigration, new MigrationsFolder("AfterMigration", folderNames.AfterMigration, EveryTime, TransactionHandling: TransactionHandling.Autonomous) },
         };
+        foldersConfiguration.CreateDatabase = new MigrationsFolder("CreateDatabase", folderNames.CreateDatabase, AnyTime, ConnectionType.Admin, TransactionHandling.Autonomous);
+        foldersConfiguration.DropDatabase = new MigrationsFolder("DropDatabase", folderNames.DropDatabase, AnyTime, ConnectionType.Admin, TransactionHandling.Autonomous);
+        
+        return foldersConfiguration;
     }
 
 }

--- a/grate/Configuration/IFoldersConfiguration.cs
+++ b/grate/Configuration/IFoldersConfiguration.cs
@@ -4,4 +4,6 @@ namespace grate.Configuration;
 
 public interface IFoldersConfiguration: IDictionary<string, MigrationsFolder?>
 {
+    MigrationsFolder? CreateDatabase { get; set; }
+    MigrationsFolder? DropDatabase { get; set; }
 }

--- a/grate/Configuration/IKnownFolderNames.cs
+++ b/grate/Configuration/IKnownFolderNames.cs
@@ -3,6 +3,8 @@
 public interface IKnownFolderNames
 {
     string BeforeMigration { get; }
+    string CreateDatabase { get; }
+    string DropDatabase { get; }
     string AlterDatabase { get; }
     string RunAfterCreateDatabase { get; }
     string RunBeforeUp { get; }

--- a/grate/Configuration/KnownFolderKeys.cs
+++ b/grate/Configuration/KnownFolderKeys.cs
@@ -5,6 +5,7 @@ namespace grate.Configuration;
 public static class KnownFolderKeys
 {
     public const string BeforeMigration = nameof(BeforeMigration);
+    public const string CreateDatabase = nameof(CreateDatabase);
     public const string AlterDatabase = nameof(AlterDatabase);
     public const string RunAfterCreateDatabase = nameof(RunAfterCreateDatabase);
     public const string RunBeforeUp = nameof(RunBeforeUp);

--- a/grate/Configuration/KnownFolderNames.cs
+++ b/grate/Configuration/KnownFolderNames.cs
@@ -3,6 +3,8 @@
 public record KnownFolderNames: IKnownFolderNames
 {
     public string BeforeMigration { get; init; } = "beforeMigration";
+    public string CreateDatabase { get; init; } = "createDatabase";
+    public string DropDatabase { get; init; } = "dropDatabase";
     public string AlterDatabase { get; init; } = "alterDatabase";
     public string RunAfterCreateDatabase { get; init; } = "runAfterCreateDatabase";
     public string RunBeforeUp { get; init; } = "runBeforeUp";

--- a/grate/Migration/GrateMigrator.cs
+++ b/grate/Migration/GrateMigrator.cs
@@ -242,9 +242,9 @@ public class GrateMigrator : IAsyncDisposable
             var createDatabaseFolder = config.Folders?.CreateDatabase;
             var database = _migrator.Database;
             
-            var path = Wrap(config.SqlFilesDirectory, createDatabaseFolder.Path);
+            var path = Wrap(config.SqlFilesDirectory, createDatabaseFolder?.Path  ?? "zz-xx-øø-definitely-does-not-exist");
             
-            if (path.Exists)
+            if (createDatabaseFolder is not null && path.Exists)
             {
                 //await LogAndProcess(config.SqlFilesDirectory, folder!, changeDropFolder, versionId, folder!.ConnectionType, folder.TransactionHandling);
                 var changeDropFolder = ChangeDropFolder(config, database.ServerName, database.DatabaseName);

--- a/grate/Migration/IDbMigrator.cs
+++ b/grate/Migration/IDbMigrator.cs
@@ -26,7 +26,12 @@ public interface IDbMigrator: IAsyncDisposable
     Task<long> VersionTheDatabase(string newVersion);
     Task OpenAdminConnection();
     Task CloseAdminConnection();
+    
     Task<bool> RunSql(string sql, string scriptName, MigrationType migrationType, long versionId,
+        GrateEnvironment? environment,
+        ConnectionType connectionType, TransactionHandling transactionHandling);
+
+    Task<bool> RunSqlWithoutLogging(string sql, string scriptName,
         GrateEnvironment? environment,
         ConnectionType connectionType, TransactionHandling transactionHandling);
 

--- a/grate/Migration/MariaDbDatabase.cs
+++ b/grate/Migration/MariaDbDatabase.cs
@@ -30,7 +30,7 @@ public class MariaDbDatabase : AnsiSqlDatabase
 
         // We need to kill any active connections to get MariaDB to actually delete the database,
         // and stop accepting new connections to it. So we create a list of the
-        // active sessions against our databse, and create 'KILL X' statements (where X is session id).
+        // active sessions against our database, and create 'KILL X' statements (where X is session id).
         // Then we execute the kill statements.
         var sql = $@"
 SELECT GROUP_CONCAT(CONCAT('KILL ',id,';') SEPARATOR ' ')
@@ -39,7 +39,7 @@ FROM information_schema.processlist WHERE DB = '{DatabaseName}'";
         var killStatements = await ExecuteScalarAsync<object>(AdminConnection, sql);
         if (killStatements != null && !DBNull.Value.Equals(killStatements))
         {
-            string killSql = killStatements.ToString() ?? ""; // Just to keel warnings happy
+            string killSql = killStatements.ToString() ?? ""; // Just to keep warnings happy
             await ExecuteNonQuery(AdminConnection, killSql, null);
         }
 


### PR DESCRIPTION
Allow for custom `CREATE DATABASE` and `DROP DATABASE` scripts in folders, similar to up, beforeMigration, afterMigration, etc. If you have the need for any custom create database logic, put it in this folder, and it will be used instead of the standard.