### PR TITLE
Issue #307: Set 'master' DB name per database type

### DIFF
--- a/grate.unittests/Basic/CommandLineParsing/Basic_CommandLineParsing.cs
+++ b/grate.unittests/Basic/CommandLineParsing/Basic_CommandLineParsing.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using grate.Commands;
 using grate.Configuration;
 using grate.Infrastructure;
+using grate.unittests.TestInfrastructure;
 using NUnit.Framework;
 
 namespace grate.unittests.Basic.CommandLineParsing;
@@ -63,6 +64,21 @@ public class Basic_CommandLineParsing
         var cfg = await ParseGrateConfiguration(commandline);
 
         cfg?.AdminConnectionString.Should().Be(database);
+    }
+
+    [TestCase(DatabaseType.mariadb)]
+    [TestCase(DatabaseType.oracle)]
+    [TestCase(DatabaseType.postgresql)]
+    [TestCase(DatabaseType.sqlite)]
+    [TestCase(DatabaseType.sqlserver)]
+    public async Task DefaultAdminConnectionString(DatabaseType databaseType)
+    {
+        var commandline = $"--connectionstring=;Database=jalla --databasetype={databaseType}";
+        var cfg = await ParseGrateConfiguration(commandline);
+
+        var masterDbName = TestConfig.GetTestContext(databaseType).MasterDatabase;
+
+        cfg?.AdminConnectionString.Should().Be($";Database="+masterDbName);
     }
 
     [TestCase("-f ")]

--- a/grate.unittests/TestInfrastructure/OracleGrateTestContext.cs
+++ b/grate.unittests/TestInfrastructure/OracleGrateTestContext.cs
@@ -29,6 +29,7 @@ internal class OracleGrateTestContext : TestContextBase, IGrateTestContext, IDoc
 
     public DatabaseType DatabaseType => DatabaseType.oracle;
     public bool SupportsTransaction => false;
+
     public string DatabaseTypeName => "Oracle";
     public string MasterDatabase => "oracle";
 

--- a/grate.unittests/TestInfrastructure/TestConfig.cs
+++ b/grate.unittests/TestInfrastructure/TestConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using grate.Configuration;
 using Microsoft.Extensions.Logging;
 using static System.StringSplitOptions;
 
@@ -67,5 +68,15 @@ public static class TestConfig
        
         return path;
     }
-        
+
+    public static IGrateTestContext GetTestContext(DatabaseType databaseType) => databaseType switch
+    {
+        DatabaseType.mariadb => new MariaDbGrateTestContext(),
+        DatabaseType.oracle => new OracleGrateTestContext(),
+        DatabaseType.postgresql => new PostgreSqlGrateTestContext(),
+        DatabaseType.sqlite => new SqliteGrateTestContext(),
+        DatabaseType.sqlserver => new SqlServerGrateTestContext(),
+        _ => throw new ArgumentOutOfRangeException(nameof(databaseType), databaseType.ToString())
+    };
+
 }

--- a/grate/Configuration/GrateConfiguration.cs
+++ b/grate/Configuration/GrateConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using grate.Infrastructure;
@@ -34,14 +35,15 @@ public record GrateConfiguration
 
     public string? AccessToken { get; set; } = null;
 
-    private static string? WithAdminDb(string? connectionString)
+    private string? WithAdminDb(string? connectionString)
     {
         if (string.IsNullOrEmpty(connectionString))
         {
             return connectionString;
         }
         var pattern = new Regex("(.*;\\s*(?:Initial Catalog|Database)=)([^;]*)(.*)");
-        var replaced = pattern.Replace(connectionString, "$1master$3");
+        var replacement = $"$1{GetMasterDbName(DatabaseType)}$3";
+        var replaced = pattern.Replace(connectionString, replacement);
         return replaced;
     }
 
@@ -119,4 +121,15 @@ public record GrateConfiguration
     /// If specified, location of the backup file to use when restoring
     /// </summary>
     public string? Restore { get; init; }
+
+    private static string GetMasterDbName(DatabaseType databaseType) => databaseType switch
+    {
+        DatabaseType.mariadb => "mysql",
+        DatabaseType.oracle => "oracle",
+        DatabaseType.postgresql => "postgres",
+        DatabaseType.sqlite => "master",
+        DatabaseType.sqlserver => "master",
+        _ => throw new ArgumentOutOfRangeException(nameof(databaseType), databaseType.ToString())
+    };
+
 }


### PR DESCRIPTION
The different database systems have different 'master' databases. Use the sensible default for admin db connection string, instead of just 'master', which only makes sense for SQL server.

Solves #307 