### PR TITLE
Bug #232: Disable connection pooling by default for SqlServer

### DIFF
--- a/grate.unittests/Basic/Infrastructure/SqlServer/SqlServerDatabase_.cs
+++ b/grate.unittests/Basic/Infrastructure/SqlServer/SqlServerDatabase_.cs
@@ -1,0 +1,50 @@
+﻿using System.Data.Common;
+using System.Threading.Tasks;
+using FluentAssertions;
+using grate.Configuration;
+using grate.Migration;
+using grate.unittests.TestInfrastructure;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace grate.unittests.Basic.Infrastructure.SqlServer;
+
+// ReSharper disable once InconsistentNaming
+public class SqlServerDatabase_
+{
+    [Test]
+    public async Task Disables_pooling_if_not_explicitly_set_in_connection_string()
+    {
+        var connStr = "Server=dummy";
+        var cfg = new GrateConfiguration() { ConnectionString = connStr };
+        var sqlServerDatabase = new InspectableSqlServerDatabase();
+        await sqlServerDatabase.InitializeConnections(cfg);
+
+        var conn = sqlServerDatabase.GetConnection();
+        var builder = new SqlConnectionStringBuilder(conn.ConnectionString);
+        builder.Pooling.Should().BeFalse();
+    }
+    
+    [Test]
+    public async Task Leaves_pooling_as_configured_if_set_explicitly_in_connection_string()
+    {
+        var connStr = "Server=dummy;Pooling=true";
+        var cfg = new GrateConfiguration() { ConnectionString = connStr };
+        var sqlServerDatabase = new InspectableSqlServerDatabase();
+        await sqlServerDatabase.InitializeConnections(cfg);
+
+        var conn = sqlServerDatabase.GetConnection();
+        var builder = new SqlConnectionStringBuilder(conn.ConnectionString);
+        builder.Pooling.Should().BeTrue();
+    }
+
+    private class InspectableSqlServerDatabase : SqlServerDatabase
+    {
+        public InspectableSqlServerDatabase() : base(TestConfig.LogFactory.CreateLogger<SqlServerDatabase>())
+        {
+        }
+
+        public DbConnection GetConnection() => base.Connection;
+    }
+}

--- a/grate.unittests/SqlServer/Database.cs
+++ b/grate.unittests/SqlServer/Database.cs
@@ -1,7 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading.Tasks;
 using FluentAssertions;
+using grate.Configuration;
+using grate.Migration;
 using grate.unittests.TestInfrastructure;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace grate.unittests.SqlServer;
@@ -29,5 +34,4 @@ public class Database: Generic.GenericDatabase
         // There should be no errors running the migration
         Assert.DoesNotThrowAsync(() => migrator.Migrate());
     }
-
 }

--- a/grate.unittests/SqlServer/Database.cs
+++ b/grate.unittests/SqlServer/Database.cs
@@ -1,12 +1,7 @@
 ﻿using System.Collections.Generic;
-using System.Data.Common;
 using System.Threading.Tasks;
 using FluentAssertions;
-using grate.Configuration;
-using grate.Migration;
 using grate.unittests.TestInfrastructure;
-using Microsoft.Data.SqlClient;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 namespace grate.unittests.SqlServer;

--- a/grate/Migration/SqlServerDatabase.cs
+++ b/grate/Migration/SqlServerDatabase.cs
@@ -19,9 +19,18 @@ public class SqlServerDatabase : AnsiSqlDatabase
     protected override bool SupportsSchemas => true;
     protected override DbConnection GetSqlConnection(string? connectionString)
     {
+        // If pooling is not explicitly mentioned in the connection string, turn it off, as enabling it
+        // might lead to problems in more scenarios than it (potentially) solves, in the most
+        // common grate scenarios.
+        if (!(connectionString ?? "").Contains("Pooling", StringComparison.InvariantCultureIgnoreCase))
+        {
+            var builder = new SqlConnectionStringBuilder(connectionString) { Pooling = false };
+            connectionString = builder.ConnectionString;
+        }
+        
         var conn = new SqlConnection(connectionString);
         conn.AccessToken = AccessToken;
-
+        
         return conn;
     }
     protected string? AccessToken { get; private set; }

--- a/grate/Migration/SqlServerDatabase.cs
+++ b/grate/Migration/SqlServerDatabase.cs
@@ -30,7 +30,7 @@ public class SqlServerDatabase : AnsiSqlDatabase
         
         var conn = new SqlConnection(connectionString);
         conn.AccessToken = AccessToken;
-        
+
         return conn;
     }
     protected string? AccessToken { get; private set; }


### PR DESCRIPTION
Microsoft.Data.SqlClient v 5.x has connection pooling enabled by default. This can create issues for grate due to that we expect connections to actually be closed when we close them. If they aren't (which they aren't when connection pooling is enabled), some scripts, that alter the state of the database, might fail.

Closes #232 