### PR TITLE
SQL*Plus compatible separator

### DIFF
--- a/grate/Infrastructure/OracleSyntax.cs
+++ b/grate/Infrastructure/OracleSyntax.cs
@@ -11,7 +11,7 @@ public class OracleSyntax : ISyntax
             const string strings = @"(?<KEEP1>'[^']*')";
             const string dashComments = @"(?<KEEP1>--.*$)";
             const string starComments = @"(?<KEEP1>/\*[\S\s]*?\*/)";
-            const string separator = @"(?<KEEP1>^|\s)(?<BATCHSPLITTER>GO)(?<KEEP2>\s|;|$)";
+            const string separator = @"(?<KEEP1>^|\s)(?<BATCHSPLITTER>GO|/)(?<KEEP2>\s|;|$)";
             return strings + "|" + dashComments + "|" + starComments + "|" + separator;
         }
     }


### PR DESCRIPTION
For Oracle databases, allow "/" as  a batch separator for compatibility with SQL*Plus syntax. 

https://stackoverflow.com/questions/29961595/sql-server-go-equivalent-in-oracle