### PR TITLE
Bug #247: Don't trim assemblies on Windows - SNI problems

### DIFF
--- a/grate/grate.csproj
+++ b/grate/grate.csproj
@@ -56,4 +56,8 @@ up using modern .NET 6/7.
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SelfContained)' == 'true' And $(RuntimeIdentifier.StartsWith('win-'))">
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
There are some issues with SNI dlls (native C++ DLL used only on Windows when connecting to SQL server) when trimming assemblies. So, avoid trimming on Windows. It makes the binary 40MB instead of 20MB, but, nevermind, that's a minor issue nowadays.

See https://learn.microsoft.com/en-us/sql/connect/ado-net/sqlclient-troubleshooting-guide?view=sql-server-ver16#issues-in-net-core-applications

Solves #247 