### PR TITLE
Don't try to create the LocalApplicationData folder as default

### DIFF
--- a/grate/Configuration/DefaultConfiguration.cs
+++ b/grate/Configuration/DefaultConfiguration.cs
@@ -15,7 +15,7 @@ public static class DefaultConfiguration
     public static readonly string DefaultVersionXPath = @"//buildInfo/version";
     public static readonly string DefaultFilesDirectory = @".";
     public static readonly string DefaultServerName = "(local)";
-    public static readonly string DefaultOutputPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "grate");
+    public static readonly string DefaultOutputPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), "grate");
     public static readonly string LoggingFile = @"C:\Temp\grate\grate.changes.log";
     public static readonly int DefaultCommandTimeout = 60;
     public static readonly int DefaultAdminCommandTimeout = 300;


### PR DESCRIPTION
Ref comment here: https://github.com/erikbra/grate/issues/335#issuecomment-1557070727
grate fails on read-only instances. No need to try to create this folder in static initialisation, as this folder can be overridden.