### PR TITLE
chore: Clean up compiler warnings/analysers

### DIFF
--- a/grate.unittests/Basic/CommandLineParsing/FolderConfiguration_.cs
+++ b/grate.unittests/Basic/CommandLineParsing/FolderConfiguration_.cs
@@ -24,8 +24,7 @@ public class FolderConfiguration_
     public async Task Default()
     {
         var cfg = await ParseGrateConfiguration("--sqlfilesdirectory=/tmp");
-
-        var parent = cfg?.SqlFilesDirectory ?? new DirectoryInfo("/tmp");
+        _ = cfg?.SqlFilesDirectory ?? new DirectoryInfo("/tmp");
 
         var expected = FoldersConfiguration.Default(null);
         var actual = cfg?.Folders;
@@ -38,7 +37,7 @@ public class FolderConfiguration_
     public async Task Default_With_Overrides(string commandLine, Func<KnownFolderNames, KnownFolderNames> applyExpectedOverrides)
     {
         var cfg = await ParseGrateConfiguration("--sqlfilesdirectory=/tmp", commandLine);
-        var parent = cfg?.SqlFilesDirectory ?? new DirectoryInfo("/tmp");
+        _ = cfg?.SqlFilesDirectory ?? new DirectoryInfo("/tmp");
         var folderConfig = applyExpectedOverrides(KnownFolderNames.Default);
         var expected = FoldersConfiguration.Default(folderConfig);
         
@@ -79,7 +78,7 @@ public class FolderConfiguration_
     private static TestCaseData GetTestCase(
         string folderArg,
         Func<KnownFolderNames, KnownFolderNames> expectedOverrides,
-        [CallerArgumentExpression("expectedOverrides")] string overridesText = ""
+        [CallerArgumentExpression(nameof(expectedOverrides))] string overridesText = ""
     ) => new TestCaseData(folderArg, expectedOverrides).SetArgDisplayNames(folderArg, overridesText);
     
     private static TestCaseData GetCustomisedTestCase(

--- a/grate.unittests/Basic/Infrastructure/FileSystem_.cs
+++ b/grate.unittests/Basic/Infrastructure/FileSystem_.cs
@@ -99,6 +99,6 @@ public class FileSystem_
     }
 
     protected static DirectoryInfo Wrap(DirectoryInfo root, string? subFolder) =>
-        new DirectoryInfo(Path.Combine(root.ToString(), subFolder ?? ""));
+        new(Path.Combine(root.ToString(), subFolder ?? ""));
     
 }

--- a/grate.unittests/Basic/Infrastructure/FolderConfiguration/Fully_Customised_Folders.cs
+++ b/grate.unittests/Basic/Infrastructure/FolderConfiguration/Fully_Customised_Folders.cs
@@ -76,7 +76,7 @@ public class Fully_Customised_Folders
         MigrationType expectedType,
         ConnectionType expectedConnectionType,
         TransactionHandling transactionHandling,
-        [CallerArgumentExpression("folder")] string migrationsFolderDefinitionName = ""
+        [CallerArgumentExpression(nameof(folder))] string migrationsFolderDefinitionName = ""
     ) =>
         new TestCaseData(folder, expectedName, expectedType, expectedConnectionType, transactionHandling)
             .SetArgDisplayNames(

--- a/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_CustomNames.cs
+++ b/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_CustomNames.cs
@@ -19,7 +19,7 @@ namespace grate.unittests.Basic.Infrastructure.FolderConfiguration;
 // ReSharper disable once InconsistentNaming
 public class KnownFolders_CustomNames
 {
-    private static readonly Random Random = new Random();
+    private static readonly Random Random = new();
 
     [Test]
     public void Returns_folders_in_same_order_as_default()
@@ -114,7 +114,7 @@ public class KnownFolders_CustomNames
         MigrationType expectedType,
         ConnectionType expectedConnectionType,
         TransactionHandling transactionHandling,
-        [CallerArgumentExpression("folder")] string migrationsFolderDefinitionName = ""
+        [CallerArgumentExpression(nameof(folder))] string migrationsFolderDefinitionName = ""
     ) =>
         new TestCaseData(folder, expectedName, expectedType, expectedConnectionType, transactionHandling)
             .SetArgDisplayNames(

--- a/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_Default.cs
+++ b/grate.unittests/Basic/Infrastructure/FolderConfiguration/KnownFolders_Default.cs
@@ -90,7 +90,7 @@ public class KnownFolders_Default
         MigrationType expectedType,
         ConnectionType expectedConnectionType,
         TransactionHandling transactionHandling,
-        [CallerArgumentExpression("folder")] string migrationsFolderDefinitionName = ""
+        [CallerArgumentExpression(nameof(folder))] string migrationsFolderDefinitionName = ""
     ) =>
         new TestCaseData(folder, expectedName, expectedType, expectedConnectionType, transactionHandling)
             .SetArgDisplayNames(

--- a/grate.unittests/Basic/Migration.cs
+++ b/grate.unittests/Basic/Migration.cs
@@ -38,7 +38,7 @@ public class Migration
     }
     
     protected static DirectoryInfo Wrap(DirectoryInfo root, string? subFolder) =>
-        new DirectoryInfo(Path.Combine(root.ToString(), subFolder ?? ""));
+        new(Path.Combine(root.ToString(), subFolder ?? ""));
 
     private static IDbMigrator GetDbMigrator(bool dryRun)
     {

--- a/grate.unittests/Generic/GenericDatabase.cs
+++ b/grate.unittests/Generic/GenericDatabase.cs
@@ -218,6 +218,6 @@ public abstract class GenericDatabase
     
     
     protected static DirectoryInfo Wrap(DirectoryInfo root, string? subFolder) =>
-        new DirectoryInfo(Path.Combine(root.ToString(), subFolder ?? ""));
+        new(Path.Combine(root.ToString(), subFolder ?? ""));
     
 }

--- a/grate.unittests/Generic/Running_MigrationScripts/Failing_Scripts.cs
+++ b/grate.unittests/Generic/Running_MigrationScripts/Failing_Scripts.cs
@@ -302,7 +302,7 @@ public abstract class Failing_Scripts : MigrationsScriptsBase
 
     private static TestCaseData GetTestCase(
         MigrationsFolder? folder,
-        [CallerArgumentExpression("folder")] string migrationsFolderDefinitionName = ""
+        [CallerArgumentExpression(nameof(folder))] string migrationsFolderDefinitionName = ""
     ) =>
         new TestCaseData(folder)
             .SetArgDisplayNames(

--- a/grate.unittests/Generic/Running_MigrationScripts/MigrationsScriptsBase.cs
+++ b/grate.unittests/Generic/Running_MigrationScripts/MigrationsScriptsBase.cs
@@ -74,6 +74,6 @@ public abstract class MigrationsScriptsBase
     protected abstract IGrateTestContext Context { get; }
 
     protected static DirectoryInfo Wrap(DirectoryInfo root, string? subFolder) =>
-        new DirectoryInfo(Path.Combine(root.ToString(), subFolder ?? ""));
+        new(Path.Combine(root.ToString(), subFolder ?? ""));
 
 }

--- a/grate.unittests/SqlServer/Running_MigrationScripts/RestoreDatabase.cs
+++ b/grate.unittests/SqlServer/Running_MigrationScripts/RestoreDatabase.cs
@@ -18,13 +18,11 @@ public class RestoreDatabase : SqlServerScriptsBase
     [OneTimeSetUp]
     public async Task RunBeforeTest()
     {
-        await using (var conn = Context.CreateDbConnection("master"))
-        {
-            await conn.ExecuteAsync("use [master] CREATE DATABASE [test]");
-            await conn.ExecuteAsync("use [test] CREATE TABLE dbo.Table_1 (column1 int NULL)");
-            await conn.ExecuteAsync($"BACKUP DATABASE [test] TO  DISK = '{_backupPath}'");
-            await conn.ExecuteAsync("use [master] DROP DATABASE [test]");
-        }
+        await using var conn = Context.CreateDbConnection("master");
+        await conn.ExecuteAsync("use [master] CREATE DATABASE [test]");
+        await conn.ExecuteAsync("use [test] CREATE TABLE dbo.Table_1 (column1 int NULL)");
+        await conn.ExecuteAsync($"BACKUP DATABASE [test] TO  DISK = '{_backupPath}'");
+        await conn.ExecuteAsync("use [master] DROP DATABASE [test]");
     }
         
     [Test]

--- a/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/RestoreDatabase.cs
+++ b/grate.unittests/SqlServerCaseSensitive/Running_MigrationScripts/RestoreDatabase.cs
@@ -18,13 +18,11 @@ namespace grate.unittests.SqlServerCaseSensitive.Running_MigrationScripts
         [OneTimeSetUp]
         public async Task RunBeforeTest()
         {
-            await using (var conn = Context.CreateDbConnection("master"))
-            {
-                await conn.ExecuteAsync("use [master] CREATE DATABASE [test]");
-                await conn.ExecuteAsync("use [test] CREATE TABLE dbo.Table_1 (column1 int NULL)");
-                await conn.ExecuteAsync($"BACKUP DATABASE [test] TO  DISK = '{_backupPath}'");
-                await conn.ExecuteAsync("use [master] DROP DATABASE [test]");
-            }
+            await using var conn = Context.CreateDbConnection("master");
+            await conn.ExecuteAsync("use [master] CREATE DATABASE [test]");
+            await conn.ExecuteAsync("use [test] CREATE TABLE dbo.Table_1 (column1 int NULL)");
+            await conn.ExecuteAsync($"BACKUP DATABASE [test] TO  DISK = '{_backupPath}'");
+            await conn.ExecuteAsync("use [master] DROP DATABASE [test]");
         }
 
         [Test]

--- a/grate.unittests/TestInfrastructure/Docker.cs
+++ b/grate.unittests/TestInfrastructure/Docker.cs
@@ -25,13 +25,10 @@ public static class Docker
         var hostPortList = await RunDockerCommand(findPortArgs);
         var hostPort = hostPortList.Split(" ", StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
 
-        if (hostPort is null)
-        {
-            throw new TestInfrastructureSetupException(
-                $"Unable to get host port from docker run output '${hostPortList}'");
-        }
-
-        return (serverName, int.Parse(hostPort));
+        return hostPort is null
+            ? throw new TestInfrastructureSetupException(
+                $"Unable to get host port from docker run output '${hostPortList}'")
+            : ((string containerId, int port))(serverName, int.Parse(hostPort));
     }
 
     public static async Task<string> Delete(string container)

--- a/grate.unittests/TestInfrastructure/NUnitLogger.cs
+++ b/grate.unittests/TestInfrastructure/NUnitLogger.cs
@@ -42,7 +42,7 @@ public class NUnitLogger : ILogger
         TestContext.Progress.WriteLine($"[{ts}] {shortName,-25} {formatter(state, exception)}");
     }
 
-    private string Shorten(string name) => name.Replace("grate.Migration.", "");
+    private static string Shorten(string name) => name.Replace("grate.Migration.", "");
 }
 #pragma warning restore CS8603 // Possible null reference return.
 

--- a/grate.unittests/TestInfrastructure/OracleSplitterContext.cs
+++ b/grate.unittests/TestInfrastructure/OracleSplitterContext.cs
@@ -8,7 +8,7 @@ public static class OracleSplitterContext
 
     public static class FullSplitter
     {
-        public static string PLSqlStatement = @"
+        public static readonly string PLSqlStatement = @"
 BOB1
 /
 
@@ -99,7 +99,7 @@ INSERT [dbo].[Foo] ([Bar]) VALUES (N'/ speed racer, / speed racer, / speed racer
 
 /";
 
-        public static string PLSqlStatementScrubbed = @"
+        public static readonly string PLSqlStatementScrubbed = @"
 BOB1
 " + StatementSplitter.BatchTerminatorReplacementString + @"
 
@@ -190,7 +190,7 @@ INSERT [dbo].[Foo] ([Bar]) VALUES (N'/ speed racer, / speed racer, / speed racer
 
 " + StatementSplitter.BatchTerminatorReplacementString + @"";
 
-        public static string plsql_statement =
+        public static readonly string plsql_statement =
             @"
 SQL1;
 ;
@@ -204,7 +204,7 @@ INSERT into Table (columnname) values ("";"");
 UPDATE Table set columnname="";"";
 END;
 ";
-        public static string plsql_statement_scrubbed = @"
+        public static readonly string plsql_statement_scrubbed = @"
 SQL1;
 " + StatementSplitter.BatchTerminatorReplacementString + @"
 SQL2;

--- a/grate.unittests/TestInfrastructure/SqlServerSplitterContext.cs
+++ b/grate.unittests/TestInfrastructure/SqlServerSplitterContext.cs
@@ -8,7 +8,7 @@ public static class SqlServerSplitterContext
 
     public static class FullSplitter
     {
-        public static string tsql_statement = @"
+        public static readonly string tsql_statement = @"
 BOB1
 GO
 
@@ -99,7 +99,7 @@ INSERT [dbo].[Foo] ([Bar]) VALUES (N'Go speed racer, go speed racer, go speed ra
 
 GO";
 
-        public static string tsql_statement_scrubbed = @"
+        public static readonly string tsql_statement_scrubbed = @"
 BOB1
 " + StatementSplitter.BatchTerminatorReplacementString + @"
 
@@ -190,7 +190,7 @@ INSERT [dbo].[Foo] ([Bar]) VALUES (N'Go speed racer, go speed racer, go speed ra
 
 " + StatementSplitter.BatchTerminatorReplacementString + @"";
 
-        public static string plsql_statement =
+        public static readonly string plsql_statement =
             @"
 SQL1;
 ;
@@ -204,7 +204,7 @@ INSERT into Table (columnname) values ("";"");
 UPDATE Table set columnname="";"";
 END;
 ";
-        public static string plsql_statement_scrubbed = @"
+        public static readonly string plsql_statement_scrubbed = @"
 SQL1;
 " + StatementSplitter.BatchTerminatorReplacementString + @"
 SQL2;

--- a/grate/Exceptions/MigrationFailed.cs
+++ b/grate/Exceptions/MigrationFailed.cs
@@ -7,15 +7,15 @@ namespace grate.Exceptions;
 
 public class MigrationFailed: AggregateException
 {
-    private const string _message = "Migration failed due to errors";
+    private const string ErrorMessage = "Migration failed due to errors";
 
     public MigrationFailed(IEnumerable<Exception> exceptions)
-        : base(_message, exceptions)
+        : base(ErrorMessage, exceptions)
     {
     }
     
     public MigrationFailed(params Exception[] exceptions)
-        : base(_message, exceptions)
+        : base(ErrorMessage, exceptions)
     { }
 
     public override string Message
@@ -28,7 +28,7 @@ public class MigrationFailed: AggregateException
             }
 
             StringBuilder sb = new StringBuilder();
-            sb.Append(_message);
+            sb.Append(ErrorMessage);
             sb.Append(":\n");
             for (int i = 0; i < InnerExceptions.Count; i++)
             {

--- a/grate/Exceptions/UnknownConnectionType.cs
+++ b/grate/Exceptions/UnknownConnectionType.cs
@@ -6,7 +6,7 @@ namespace grate.Exceptions;
 public class UnknownConnectionType: ArgumentOutOfRangeException
 {
     public UnknownConnectionType(object? connectionType,
-        [CallerArgumentExpression("connectionType")] string argumentName = "")
+        [CallerArgumentExpression(nameof(connectionType))] string argumentName = "")
         : base(argumentName, connectionType, "Unknown connection type: " + connectionType)
     { }
 }

--- a/grate/Exceptions/UnknownTransactionHandling.cs
+++ b/grate/Exceptions/UnknownTransactionHandling.cs
@@ -6,7 +6,7 @@ namespace grate.Exceptions;
 public class UnknownTransactionHandling: ArgumentOutOfRangeException
 {
     public UnknownTransactionHandling(object? transactionHandling,
-        [CallerArgumentExpression("transactionHandling")] string argumentName = "")
+        [CallerArgumentExpression(nameof(transactionHandling))] string argumentName = "")
         : base(argumentName, transactionHandling, "Unknown transaction handling : " + transactionHandling)
     { }
 }

--- a/grate/Infrastructure/GrateConsoleColor.cs
+++ b/grate/Infrastructure/GrateConsoleColor.cs
@@ -39,26 +39,26 @@ public record GrateConsoleColor
             // ReSharper restore MemberHidesStaticFromOuterClass
         }
             
-        public static readonly GrateConsoleColor Default = new GrateConsoleColor(AnsiColors.Default, ConsoleColor.White); 
+        public static readonly GrateConsoleColor Default = new(AnsiColors.Default, ConsoleColor.White); 
         public static readonly GrateConsoleColor Info = Rgb(23, 162, 184);
-        public static readonly GrateConsoleColor Black = new GrateConsoleColor(AnsiColors.Black, ConsoleColor.Black);
-        public static readonly GrateConsoleColor DarkRed = new GrateConsoleColor(AnsiColors.DarkRed, ConsoleColor.DarkRed);
-        public static readonly GrateConsoleColor DarkGreen = new GrateConsoleColor(AnsiColors.DarkGreen, ConsoleColor.DarkGreen);
-        public static readonly GrateConsoleColor DarkYellow = new GrateConsoleColor(AnsiColors.DarkYellow, ConsoleColor.DarkYellow);
-        public static readonly GrateConsoleColor DarkBlue = new GrateConsoleColor(AnsiColors.DarkBlue, ConsoleColor.DarkBlue);
-        public static readonly GrateConsoleColor DarkMagenta = new GrateConsoleColor(AnsiColors.DarkMagenta, ConsoleColor.DarkMagenta);
-        public static readonly GrateConsoleColor DarkCyan = new GrateConsoleColor(AnsiColors.DarkCyan, ConsoleColor.DarkCyan);
-        public static readonly GrateConsoleColor Gray = new GrateConsoleColor(AnsiColors.Gray, ConsoleColor.Gray);
+        public static readonly GrateConsoleColor Black = new(AnsiColors.Black, ConsoleColor.Black);
+        public static readonly GrateConsoleColor DarkRed = new(AnsiColors.DarkRed, ConsoleColor.DarkRed);
+        public static readonly GrateConsoleColor DarkGreen = new(AnsiColors.DarkGreen, ConsoleColor.DarkGreen);
+        public static readonly GrateConsoleColor DarkYellow = new(AnsiColors.DarkYellow, ConsoleColor.DarkYellow);
+        public static readonly GrateConsoleColor DarkBlue = new(AnsiColors.DarkBlue, ConsoleColor.DarkBlue);
+        public static readonly GrateConsoleColor DarkMagenta = new(AnsiColors.DarkMagenta, ConsoleColor.DarkMagenta);
+        public static readonly GrateConsoleColor DarkCyan = new(AnsiColors.DarkCyan, ConsoleColor.DarkCyan);
+        public static readonly GrateConsoleColor Gray = new(AnsiColors.Gray, ConsoleColor.Gray);
         public static readonly GrateConsoleColor DarkGray = Rgb(192,192,192);
-        public static readonly GrateConsoleColor Red = new GrateConsoleColor(AnsiColors.Red, ConsoleColor.Red);
-        public static readonly GrateConsoleColor Green = new GrateConsoleColor(AnsiColors.Green, ConsoleColor.Green);
-        public static readonly GrateConsoleColor Yellow = new GrateConsoleColor(AnsiColors.Yellow, ConsoleColor.Yellow);
-        public static readonly GrateConsoleColor Blue = new GrateConsoleColor(AnsiColors.Blue, ConsoleColor.Blue);
-        public static readonly GrateConsoleColor Magenta = new GrateConsoleColor(AnsiColors.Magenta, ConsoleColor.Magenta);
-        public static readonly GrateConsoleColor Cyan = new GrateConsoleColor(AnsiColors.Cyan, ConsoleColor.Cyan);
-        public static readonly GrateConsoleColor White = new GrateConsoleColor(AnsiColors.White, ConsoleColor.White);
+        public static readonly GrateConsoleColor Red = new(AnsiColors.Red, ConsoleColor.Red);
+        public static readonly GrateConsoleColor Green = new(AnsiColors.Green, ConsoleColor.Green);
+        public static readonly GrateConsoleColor Yellow = new(AnsiColors.Yellow, ConsoleColor.Yellow);
+        public static readonly GrateConsoleColor Blue = new(AnsiColors.Blue, ConsoleColor.Blue);
+        public static readonly GrateConsoleColor Magenta = new(AnsiColors.Magenta, ConsoleColor.Magenta);
+        public static readonly GrateConsoleColor Cyan = new(AnsiColors.Cyan, ConsoleColor.Cyan);
+        public static readonly GrateConsoleColor White = new(AnsiColors.White, ConsoleColor.White);
 
-        private static GrateConsoleColor Rgb(int r, int g, int b) => new GrateConsoleColor(AnsiColors.Rgb(r, g, b), ConsoleColor.Gray);
+        private static GrateConsoleColor Rgb(int r, int g, int b) => new(AnsiColors.Rgb(r, g, b), ConsoleColor.Gray);
 
     }
 
@@ -82,18 +82,18 @@ public record GrateConsoleColor
             // ReSharper restore MemberHidesStaticFromOuterClass
         }
             
-        public static readonly GrateConsoleColor Default = new GrateConsoleColor(AnsiColors.Default, ConsoleColor.Black); 
+        public static readonly GrateConsoleColor Default = new(AnsiColors.Default, ConsoleColor.Black); 
         public static readonly GrateConsoleColor Info = Rgb(23, 162, 184);
-        public static readonly GrateConsoleColor Black = new GrateConsoleColor(AnsiColors.Black, ConsoleColor.Black);
-        public static readonly GrateConsoleColor DarkRed = new GrateConsoleColor(AnsiColors.DarkRed, ConsoleColor.DarkRed);
-        public static readonly GrateConsoleColor DarkGreen = new GrateConsoleColor(AnsiColors.DarkGreen, ConsoleColor.DarkGreen);
-        public static readonly GrateConsoleColor DarkYellow = new GrateConsoleColor(AnsiColors.DarkYellow, ConsoleColor.DarkYellow);
-        public static readonly GrateConsoleColor DarkBlue = new GrateConsoleColor(AnsiColors.DarkBlue, ConsoleColor.DarkBlue);
-        public static readonly GrateConsoleColor DarkMagenta = new GrateConsoleColor(AnsiColors.DarkMagenta, ConsoleColor.DarkMagenta);
-        public static readonly GrateConsoleColor DarkCyan = new GrateConsoleColor(AnsiColors.DarkCyan, ConsoleColor.DarkCyan);
-        public static readonly GrateConsoleColor Gray = new GrateConsoleColor(AnsiColors.Gray, ConsoleColor.Gray);
+        public static readonly GrateConsoleColor Black = new(AnsiColors.Black, ConsoleColor.Black);
+        public static readonly GrateConsoleColor DarkRed = new(AnsiColors.DarkRed, ConsoleColor.DarkRed);
+        public static readonly GrateConsoleColor DarkGreen = new(AnsiColors.DarkGreen, ConsoleColor.DarkGreen);
+        public static readonly GrateConsoleColor DarkYellow = new(AnsiColors.DarkYellow, ConsoleColor.DarkYellow);
+        public static readonly GrateConsoleColor DarkBlue = new(AnsiColors.DarkBlue, ConsoleColor.DarkBlue);
+        public static readonly GrateConsoleColor DarkMagenta = new(AnsiColors.DarkMagenta, ConsoleColor.DarkMagenta);
+        public static readonly GrateConsoleColor DarkCyan = new(AnsiColors.DarkCyan, ConsoleColor.DarkCyan);
+        public static readonly GrateConsoleColor Gray = new(AnsiColors.Gray, ConsoleColor.Gray);
 
-        private static GrateConsoleColor Rgb(int r, int g, int b) => new GrateConsoleColor(AnsiColors.Rgb(r, g, b), ConsoleColor.Gray);
+        private static GrateConsoleColor Rgb(int r, int g, int b) => new(AnsiColors.Rgb(r, g, b), ConsoleColor.Gray);
     }
 
 }

--- a/grate/Migration/GrateMigrator.cs
+++ b/grate/Migration/GrateMigrator.cs
@@ -59,11 +59,8 @@ public class GrateMigrator : IAsyncDisposable
         
         TransactionScope? scope = null;
         IList<Exception> exceptions = new List<Exception>();
-        string? newVersion = default;
-        long versionId = default;
-        
         dbMigrator.SetDefaultConnectionActive();
-        
+
         if (config.Drop)
         {
             await dbMigrator.DropDatabase();
@@ -84,6 +81,8 @@ public class GrateMigrator : IAsyncDisposable
         // Run these first without a transaction, to make sure the tables are created even on a potential rollback
         await CreateGrateStructure(dbMigrator);
 
+        string? newVersion;
+        long versionId;
         (versionId, newVersion) = await VersionTheDatabase(dbMigrator);
 
         Separator('=');
@@ -241,8 +240,8 @@ public class GrateMigrator : IAsyncDisposable
             var config = dbMigrator.Configuration;
             var createDatabaseFolder = config.Folders?.CreateDatabase;
             var database = _migrator.Database;
-            
-            var path = Wrap(config.SqlFilesDirectory, createDatabaseFolder?.Path  ?? "zz-xx-øø-definitely-does-not-exist");
+
+            var path = Wrap(config.SqlFilesDirectory, createDatabaseFolder?.Path ?? "zz-xx-øø-definitely-does-not-exist");
             
             if (createDatabaseFolder is not null && path.Exists)
             {
@@ -269,7 +268,7 @@ public class GrateMigrator : IAsyncDisposable
         await dbMigrator.RestoreDatabase(backupPath);
     }
 
-    private DirectoryInfo Wrap(DirectoryInfo root, string subFolder) => new(Path.Combine(root.ToString(), subFolder));
+    private static DirectoryInfo Wrap(DirectoryInfo root, string subFolder) => new(Path.Combine(root.ToString(), subFolder));
 
     private async Task LogAndProcess(DirectoryInfo root, MigrationsFolder folder, string changeDropFolder, long versionId, ConnectionType connectionType, TransactionHandling transactionHandling)
     {

--- a/grate/Migration/MariaDbDatabase.cs
+++ b/grate/Migration/MariaDbDatabase.cs
@@ -19,10 +19,14 @@ public class MariaDbDatabase : AnsiSqlDatabase
 
     protected override DbConnection GetSqlConnection(string? connectionString)
     {
+        //if we actually get a null here we're in trouble, but the cascading changes of making the param
+        //non-null are significant.
+        connectionString ??= "";
+
         // If pipelining is not explicitly mentioned in the connection string, turn it off, as enabling it
         // might lead to problems in more scenarios than it (potentially) solves, in the most
         // common grate scenarios.
-        if (!(connectionString ?? "").Contains("Pipelining", StringComparison.InvariantCultureIgnoreCase))
+        if (!connectionString.Contains("Pipelining", StringComparison.InvariantCultureIgnoreCase))
         {
             var builder = new MySqlConnectionStringBuilder(connectionString) { Pipelining = false };
             connectionString = builder.ConnectionString;

--- a/grate/Migration/SqlServerDatabase.cs
+++ b/grate/Migration/SqlServerDatabase.cs
@@ -27,9 +27,11 @@ public class SqlServerDatabase : AnsiSqlDatabase
             var builder = new SqlConnectionStringBuilder(connectionString) { Pooling = false };
             connectionString = builder.ConnectionString;
         }
-        
-        var conn = new SqlConnection(connectionString);
-        conn.AccessToken = AccessToken;
+
+        var conn = new SqlConnection(connectionString)
+        {
+            AccessToken = AccessToken
+        };
 
         return conn;
     }

--- a/grate/Program.cs
+++ b/grate/Program.cs
@@ -57,7 +57,7 @@ public static class Program
         catch (MigrationFailed ex)
         {
             var logger = _serviceProvider.GetRequiredService<ILogger<GrateMigrator>>();
-            logger.LogError(ex.Message);
+            logger.LogError(ex, "{ErrorMessage}", ex.Message);
         }
 
         await WaitForLoggerToFinish();


### PR DESCRIPTION
Reduced compiler warnings/roslyn analysers significantly:

![image](https://github.com/erikbra/grate/assets/3802829/27169f06-d480-4897-849e-3e2f193a7dec)

Down to 0 warnings and 8 messages.  If you're keen to keep cleaning up I'll get the other analysers sorted as well.