### PR TITLE
Issue #357: refine postgresql batch statement splitting

### DIFF
--- a/grate/Infrastructure/PostgreSqlSyntax.cs
+++ b/grate/Infrastructure/PostgreSqlSyntax.cs
@@ -6,11 +6,13 @@ public class PostgreSqlSyntax : ISyntax
     {
         get
         {
-            const string strings = @"(?<KEEP1>'[^']*')";
+            const string strings = @"(?<KEEP1>'([^']|\'\')*')";
+            const string backslashEscapedSrings = @"(?<KEEP1>E(?<!\\)('[\S\s]*?(?<!\\)'))";
+            const string dollarQuotedStrings = @"(?<KEEP1>\$(?'tag'\w*)\$[\S\s]*?\$\k'tag'\$)";
             const string dashComments = @"(?<KEEP1>--.*$)";
             const string starComments = @"(?<KEEP1>/\*[\S\s]*?\*/)";
             const string separator = @"(?<KEEP1>.*)(?<BATCHSPLITTER>;)(?<KEEP2>.*)";
-            return strings + "|" + dashComments + "|" + starComments + "|" + separator;
+            return strings + "|" + backslashEscapedSrings + "|" + dollarQuotedStrings + "|" + dashComments + "|" + starComments + "|" + separator;
         }
     }
 


### PR DESCRIPTION
Refined the parsing of strings in order to support String Constants with C-Style Escapes and Dollar-Quoted String Constants (see https://www.postgresql.org/docs/15/sql-syntax-lexical.html).
Statements should not be split on `;` within these constants.

Relates to #357 