### PR TITLE
Issue #371: Disable SQL statement splitting for others than SQL server

### DIFF
--- a/grate/Migration/AnsiSqlDatabase.cs
+++ b/grate/Migration/AnsiSqlDatabase.cs
@@ -47,7 +47,7 @@ public abstract class AnsiSqlDatabase : IDatabase
 
     public abstract bool SupportsDdlTransactions { get; }
     public abstract bool SupportsSchemas { get; }
-    public bool SplitBatchStatements => true;
+    public virtual bool SplitBatchStatements => false;
 
     public string StatementSeparatorRegex => _syntax.StatementSeparatorRegex;
 

--- a/grate/Migration/DbMigrator.cs
+++ b/grate/Migration/DbMigrator.cs
@@ -338,7 +338,7 @@ public class DbMigrator : IDbMigrator
     }
 
 
-    private IEnumerable<string> GetStatements(string sql) => StatementSplitter.Split(sql);
+    private IEnumerable<string> GetStatements(string sql) => Database.SplitBatchStatements ? StatementSplitter.Split(sql) : new [] { sql };
 
     private void LogScriptChangedWarning(string scriptName)
     {

--- a/grate/Migration/SqlServerDatabase.cs
+++ b/grate/Migration/SqlServerDatabase.cs
@@ -17,6 +17,7 @@ public class SqlServerDatabase : AnsiSqlDatabase
 
     public override bool SupportsDdlTransactions => true;
     public override bool SupportsSchemas => true;
+    public override bool SplitBatchStatements => true;
     protected override DbConnection GetSqlConnection(string? connectionString)
     {
         // If pooling is not explicitly mentioned in the connection string, turn it off, as enabling it


### PR DESCRIPTION
There are issues, particularly for PostgreSQL and Oracle, with splitting SQL scripts into multiple statements, and execute one and one. This is discussed in e.g. https://www.roji.org/parameters-batching-and-sql-rewriting, with the conclusion that parsing SQL (including for splitting) is not a good idea to be done in SQL drivers (see especially https://github.com/npgsql/npgsql/issues/4445). 

Following this, and given that splitting SQL scripts into multiple statements has not worked for anything other than SQL server up until grate v 1.5.0, we disable the SQL statement splitting feature for all other databases than SQL server for now.

Should anyone have good arguments against this, either in general, or for one particular database type, *and* can come up with a bullet-proof way of splitting the text into statements (preferably using the native sql driver's own apis), we can consider re-introducing support for splitting for particular databases.