### PR TITLE
Bug #441: Don't use master DB unnecessarily on SQL Server

### DIFF
--- a/src/grate.sqlserver/Migration/SqlServerDatabase.cs
+++ b/src/grate.sqlserver/Migration/SqlServerDatabase.cs
@@ -45,36 +45,39 @@ public record SqlServerDatabase : AnsiSqlDatabase
         AccessToken = configuration.AccessToken;
         return base.InitializeConnections(configuration);
     }
-
-    public override async Task<bool> DatabaseExists()
-    {
-        var sql = @$"USE master;
-                    SELECT 1 FROM sys.databases WHERE [name] = @dbname";
-        try
-        {
-
-            Logger.LogInformation("Trying to check the database {DbName} database on {Server}", DatabaseName, ServerName);
-            await OpenAdminConnection();
-            var cmd = AdminConnection.CreateCommand();
-            cmd.CommandText = sql;
-
-            // dbName parameter
-            var dbNameParam = cmd.CreateParameter();
-            dbNameParam.ParameterName = "@dbname";
-            dbNameParam.Value = DatabaseName;
-            cmd.Parameters.Add(dbNameParam);
-            var result = await cmd.ExecuteScalarAsync();
-            Logger.LogInformation("Database {DbName} querying with result {Result}", DatabaseName, result);
-            return result is not null;
-
-        }
-        catch (DbException e)
-        {
-            Logger.LogDebug(e, "Got error: {ErrorMessage}", e.Message);
-            return false;
-        }
-
-    }
+    
+    // Needs admin connection, which we do not always have.
+    // Could we use the optimization _if_ we have an admin connection, and turn it off if we don't?
+    
+    // public override async Task<bool> DatabaseExists()
+    // {
+    //     var sql = @$"USE master;
+    //                 SELECT 1 FROM sys.databases WHERE [name] = @dbname";
+    //     try
+    //     {
+    //
+    //         Logger.LogInformation("Trying to check the database {DbName} database on {Server}", DatabaseName, ServerName);
+    //         await OpenAdminConnection();
+    //         var cmd = AdminConnection.CreateCommand();
+    //         cmd.CommandText = sql;
+    //
+    //         // dbName parameter
+    //         var dbNameParam = cmd.CreateParameter();
+    //         dbNameParam.ParameterName = "@dbname";
+    //         dbNameParam.Value = DatabaseName;
+    //         cmd.Parameters.Add(dbNameParam);
+    //         var result = await cmd.ExecuteScalarAsync();
+    //         Logger.LogInformation("Database {DbName} querying with result {Result}", DatabaseName, result);
+    //         return result is not null;
+    //
+    //     }
+    //     catch (DbException e)
+    //     {
+    //         Logger.LogDebug(e, "Got error: {ErrorMessage}", e.Message);
+    //         return false;
+    //     }
+    //
+    // }
     public override async Task RestoreDatabase(string backupPath)
     {
         try

--- a/unittests/MariaDB/TestInfrastructure/MariaDbGrateTestContext.cs
+++ b/unittests/MariaDB/TestInfrastructure/MariaDbGrateTestContext.cs
@@ -43,8 +43,13 @@ public class MariaDbGrateTestContext : IGrateTestContext
     {
         SelectVersion = "SELECT VERSION()",
         SleepTwoSeconds = "SELECT SLEEP(2);",
-        CreateUser = "CREATE USER '{0}'@'%' IDENTIFIED BY '{1}';",
-        GrantAccess = "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, DROP, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES ON {0}.* TO '{1}'@'%';FLUSH PRIVILEGES;"
+        CreateUser = (_, user, password) => $"CREATE USER '{user}'@'%' IDENTIFIED BY '{password}';",
+        GrantAccess =  (db, user) =>
+            $"""
+             GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, DROP, ALTER, CREATE TEMPORARY TABLES, 
+             LOCK TABLES ON {db}.* TO '{user}'@'%';
+             FLUSH PRIVILEGES;
+             """
     };
 
 

--- a/unittests/SqlServer/Database.cs
+++ b/unittests/SqlServer/Database.cs
@@ -23,7 +23,7 @@ public class Database(IGrateTestContext testContext, ITestOutputHelper testOutpu
 
         await using var migrator = GetMigrator(GetConfiguration(db.ToLower(), true)); // ToLower is important here, this reproduces the bug in #167
         // There should be no errors running the migration
-        //Assert.DoesNotThrowAsync(() => migrator.Migrate());
-        await migrator.Migrate();
+        Action action = () => migrator.Migrate();
+        action.Should().NotThrow();
     }
 }

--- a/unittests/SqlServer/TestInfrastructure/SqlServerGrateTestContext.cs
+++ b/unittests/SqlServer/TestInfrastructure/SqlServerGrateTestContext.cs
@@ -31,21 +31,15 @@ class SqlServerGrateTestContext : IGrateTestContext
     }
     public string AdminPassword => _testContainer.AdminPassword;
     public int? Port => _testContainer.TestContainer!.GetMappedPublicPort(_testContainer.Port);
-
-    //private int? ContainerPort => 1433;
-
-
-    // public string DockerCommand(string serverName, string adminPassword) =>
-    //     $"run -d --name {serverName} -e ACCEPT_EULA=Y -e SA_PASSWORD={adminPassword} -e MSSQL_PID=Developer -e MSSQL_COLLATION={ServerCollation} -P {DockerImage}";
-
+    
     public string AdminConnectionString =>
         $"Data Source=localhost,{Port};Initial Catalog=master;User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
 
     public string ConnectionString(string database) =>
-        $"Data Source=localhost,{Port};Initial Catalog={database};User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
+        $"Data Source=localhost,{Port};Initial Catalog={database};User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false;Connect Timeout=2";
 
     public string UserConnectionString(string database) =>
-        $"Data Source=localhost,{Port};Initial Catalog={database};User Id=sa;Password={AdminPassword};Encrypt=false;Pooling=false";
+        $"Data Source=localhost,{Port};Initial Catalog={database};User Id=zorro;Password=batmanZZ4;Encrypt=false;Pooling=false;Connect Timeout=2";
 
     public IDbConnection GetDbConnection(string connectionString) => new SqlConnection(connectionString);
 
@@ -60,7 +54,18 @@ class SqlServerGrateTestContext : IGrateTestContext
     public SqlStatements Sql => new()
     {
         SelectVersion = "SELECT @@VERSION",
-        SleepTwoSeconds = "WAITFOR DELAY '00:00:02'"
+        SleepTwoSeconds = "WAITFOR DELAY '00:00:02'",
+        CreateUser = (db, user, password) => 
+$"""
+    USE {db};
+    CREATE LOGIN {user} WITH PASSWORD = '{password}';
+    CREATE USER {user} FOR LOGIN {user};
+""",
+        GrantAccess = (db, user) => 
+$"""
+    USE {db};
+    ALTER ROLE db_owner ADD MEMBER {user};
+""",
     };
 
     public string ExpectedVersionPrefix => "Microsoft SQL Server 2019";

--- a/unittests/TestCommon/Generic/GenericDatabase.cs
+++ b/unittests/TestCommon/Generic/GenericDatabase.cs
@@ -159,14 +159,26 @@ public abstract class GenericDatabase(IGrateTestContext context, ITestOutputHelp
                 {
                     using var conn = Context.CreateAdminDbConnection();
                     conn.Open();
-                    
-                    var commandText = Context.Syntax.CreateDatabase(db, pwd);
-                    await conn.ExecuteAsync(commandText);
 
-                    var createUserSql = Context.Sql.CreateUser(db, uid, pwd);
-                    if (createUserSql is not null)
+                    try
                     {
-                        await conn.ExecuteAsync(createUserSql);
+                        var commandText = Context.Syntax.CreateDatabase(db, pwd);
+                        await conn.ExecuteAsync(commandText);
+                    }
+                    catch (DbException)
+                    {
+                    }
+                    
+                    try
+                    {
+                        var createUserSql = Context.Sql.CreateUser(db, uid, pwd);
+                        if (createUserSql is not null)
+                        {
+                            await conn.ExecuteAsync(createUserSql);
+                        }
+                    }
+                    catch (DbException)
+                    {
                     }
 
                     var grantAccessSql = Context.Sql.GrantAccess(db, uid);

--- a/unittests/TestCommon/TestInfrastructure/SqlStatements.cs
+++ b/unittests/TestCommon/TestInfrastructure/SqlStatements.cs
@@ -4,7 +4,7 @@ public record SqlStatements
 {
     public string SelectVersion { get; init; } = default!;
     public string SleepTwoSeconds { get; init; } = default!;
-    public string CreateUser { get; init; } = default!;
-    public string GrantAccess { get; init; } = default!;
+    public Func<string?, string?, string?, string?> CreateUser { get; init; } = (_ , _, _) => null;
+    public Func<string?, string?, string?> GrantAccess { get; init; } = (_, _) => null;
     public string LineComment { get; init; } = "--";
 }

--- a/unittests/TestCommon/TestInfrastructure/TestConfig.cs
+++ b/unittests/TestCommon/TestInfrastructure/TestConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using static System.StringComparison;
 using static System.StringSplitOptions;
 
 namespace TestCommon.TestInfrastructure;
@@ -19,11 +20,11 @@ public static class TestConfig
     }
 
     public static string? Username(string connectionString) => connectionString.Split(";", TrimEntries | RemoveEmptyEntries)
-        .SingleOrDefault(entry => entry.StartsWith("Uid"))?
+        .SingleOrDefault(entry => entry.StartsWith("Uid", OrdinalIgnoreCase) || entry.StartsWith("User Id", OrdinalIgnoreCase))?
         .Split("=", TrimEntries | RemoveEmptyEntries).Last();
 
     public static string? Password(string connectionString) => connectionString.Split(";", TrimEntries | RemoveEmptyEntries)
-        .SingleOrDefault(entry => entry.StartsWith("Password") || entry.StartsWith("Pwd"))?
+        .SingleOrDefault(entry => entry.StartsWith("Password", OrdinalIgnoreCase) || entry.StartsWith("Pwd", OrdinalIgnoreCase))?
         .Split("=", TrimEntries | RemoveEmptyEntries).Last();
 
     public static LogLevel GetLogLevel() => LogLevelFromEnvironmentVariable();


### PR DESCRIPTION
* Removed override on SqlServer 'check if database exists' that was dependent on having access to the master database
* Revived test asserts that had been commented out during NUnit -> xUnit conversion, that tested this scenario

Fixes #441 
