### PR TITLE
Issue #431: Improved error messages and -output on errors running SQL scripts

### DIFF
--- a/src/grate.core/Exceptions/MigrationException.cs
+++ b/src/grate.core/Exceptions/MigrationException.cs
@@ -1,0 +1,24 @@
+﻿using grate.Configuration;
+
+namespace grate.Exceptions;
+
+public abstract class MigrationException : Exception
+{
+    public MigrationException(MigrationsFolder folder, string file, string? message)
+        : this(folder, file, message, null) {}
+    
+    public MigrationException(MigrationsFolder folder, string file, string? message, Exception? innerException) 
+        : base(message, innerException)
+    {
+        Folder = folder;
+        File = file;
+        _message = message;
+    }
+
+    public MigrationsFolder Folder { get; set; }
+    public string File { get; set; }
+    
+    private readonly string? _message;
+
+    public override string Message => $"{File}: { _message ?? InnerException?.Message}";
+}

--- a/src/grate.core/Exceptions/MigrationFailed.cs
+++ b/src/grate.core/Exceptions/MigrationFailed.cs
@@ -1,7 +1,12 @@
-﻿using System.Text;
+﻿using System.Collections;
+using System.Data.Common;
+using System.Text;
 
 namespace grate.Exceptions;
 
+/// <summary>
+/// The whole migration failed due to errors
+/// </summary>
 public class MigrationFailed : AggregateException
 {
     private const string ErrorMessage = "Migration failed due to errors";
@@ -15,6 +20,18 @@ public class MigrationFailed : AggregateException
         : base(ErrorMessage, exceptions)
     { }
 
+    public override IDictionary Data => MigrationErrors.ToDictionary(item => item.Key, item => item.Value);
+
+    public virtual IDictionary<string, object?> MigrationErrors =>
+        InnerExceptions
+            .SelectMany(exception => exception.Data.Cast<KeyValuePair<string, object?>>())
+            .ToDictionary(entry => entry.Key, entry => entry.Value);
+
+    public bool IsTransient => 
+        InnerExceptions.OfType<DbException>().All(ex => ex.IsTransient)
+        && InnerExceptions.OfType<ScriptFailed>().All(ex => ex.IsTransient)
+        ;
+
     public override string Message
     {
         get
@@ -25,12 +42,27 @@ public class MigrationFailed : AggregateException
             }
 
             StringBuilder sb = new StringBuilder();
-            sb.Append(ErrorMessage);
-            sb.Append(":\n");
-            for (int i = 0; i < InnerExceptions.Count; i++)
+            
+            sb.Append("Migration failed due to the following errors");
+            sb.Append(":\n\n");
+
+            var migrationExceptions = InnerExceptions.OfType<MigrationException>().ToArray();
+            
+            foreach (var folderErrors in migrationExceptions.GroupBy(ex => ex.Folder))
+            {
+                var folder= folderErrors.Key;
+                sb.AppendLine($"{folder.Name} (\"{folder.Path}\"):");
+                sb.AppendLine("--------------------------------------------------------------------------------");
+                foreach (var error in folderErrors)
+                {
+                    sb.AppendLine(error.Message);
+                }
+            }
+            
+            foreach (var t in InnerExceptions.Except(migrationExceptions))
             {
                 sb.Append(" * ");
-                sb.Append(InnerExceptions[i].Message);
+                sb.Append(t.Message);
                 sb.Append('\n');
             }
             sb.Length--;

--- a/src/grate.core/Exceptions/OneTimeScriptChanged.cs
+++ b/src/grate.core/Exceptions/OneTimeScriptChanged.cs
@@ -1,8 +1,11 @@
-﻿namespace grate.Exceptions;
+﻿using grate.Configuration;
 
-public class OneTimeScriptChanged : Exception
+namespace grate.Exceptions;
+
+public class OneTimeScriptChanged : MigrationException
 {
-    public OneTimeScriptChanged(string errorMessage) : base(errorMessage)
+    public OneTimeScriptChanged(MigrationsFolder folder, string file, string errorMessage) 
+        : base(folder, file, errorMessage)
     {
     }
 }

--- a/src/grate.core/Exceptions/ScriptFailed.cs
+++ b/src/grate.core/Exceptions/ScriptFailed.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections;
+using System.Data.Common;
+using grate.Configuration;
+
+namespace grate.Exceptions;
+
+/// <summary>
+/// One script failed due to errors
+/// </summary>
+public abstract class ScriptFailed: MigrationException
+{
+    public ScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception cause)
+        : base(folder, file, null, cause)
+    {
+        this.Folder = folder;
+        this.File = file;
+        ScriptText = scriptText;
+        if (cause is DbException dbException)
+        {
+            this.DbException = dbException;
+        }
+    }
+
+    public string? ScriptText { get; }
+    public DbException? DbException { get; set; }
+    
+    private static string GetErrorMessage(MigrationsFolder folder, string file, Exception cause)
+    {
+        return
+            $"Error in folder {folder.Path}: Script '{file}' failed due to error: {cause.Message}";
+    }
+    
+    private string GetShortErrorMessage() => 
+        $"{File}: {InnerExceptionMessage}" +
+        (ErrorSnippet is { } ? $"\n{ErrorSnippet}" : ""); 
+
+    public override string Message => GetShortErrorMessage();
+
+    protected virtual string? InnerExceptionMessage => InnerException?.Message;
+        
+    public override string ToString() =>
+            GetErrorMessage(Folder, File, this.InnerException!) + "\n" 
+         + string.Join('\n', ScriptErrors.Select(item => $" * {item.Key}: {item.Value}"));
+
+    public override IDictionary Data => ScriptErrors.ToDictionary(item => item.Key, item => item.Value);
+
+    public IDictionary<string, object?> ScriptErrors
+        => DbException is { } 
+            ? GetDbScriptErrors() 
+            : GetGenericErrorDetails();
+
+    protected virtual int Position => 0;
+    
+    protected virtual (int? line, int position) LineAndPosition
+    {
+        get
+        {
+            var line = 0;
+            var pos = 0;
+            
+            if (ScriptText is { })
+            {
+                for (var i = 0; i < Position; i++)
+                {
+                    if (ScriptText[i] == '\n')
+                    {
+                        line++;
+                        pos = 0;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+                }
+            }
+            
+            return (line, pos);
+        }
+    }
+    
+    protected virtual string? LineWithError
+    {
+        get
+        {
+            if (ScriptText is { })
+            {
+                var lines = ScriptText.Split('\n');
+                var (line, _) = LineAndPosition;
+                if (line.HasValue && line.Value < lines.Length)
+                {
+                    return lines[line.Value];
+                }
+            }
+            return "";
+        }
+    }
+
+    protected virtual string? ErrorSnippet
+    {
+        get
+        {
+            var (line, pos) = LineAndPosition;
+            var textPrefix = $"({line},{pos}): ";
+            
+            var prefix = new String(' ', pos + textPrefix.Length - 1);
+            return $"({line},{pos}): " + LineWithError + "\n" +
+                prefix + "^ " + InnerExceptionMessage;
+        }
+    }
+
+    private Dictionary<string, object?> GetGenericErrorDetails() =>
+        (InnerException?.Data ?? new Dictionary<string, object?>())
+        .Cast<DictionaryEntry>()
+        .ToDictionary(entry => entry.Key.ToString()!, entry => entry.Value);
+
+    protected abstract IDictionary<string, object?> GetDbScriptErrors();
+
+
+    public bool IsTransient => DbException?.IsTransient ?? false;
+
+}

--- a/src/grate.core/Migration/AnsiSqlDatabase.cs
+++ b/src/grate.core/Migration/AnsiSqlDatabase.cs
@@ -53,6 +53,8 @@ public abstract record AnsiSqlDatabase : IDatabase
     public virtual IEnumerable<string> GetStatements(string sql)
         => SplitBatchStatements ? this.StatementSplitter.Split(sql) : new[] { sql };
 
+    public abstract void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception);
+
     public string StatementSeparatorRegex => _syntax.StatementSeparatorRegex;
 
     public string ScriptsRunTable => _syntax.TableWithSchema(SchemaName, ScriptsRunTableName);

--- a/src/grate.core/Migration/IDatabase.cs
+++ b/src/grate.core/Migration/IDatabase.cs
@@ -57,4 +57,6 @@ public interface IDatabase : IAsyncDisposable
     /// <param name="sql"></param>
     /// <returns></returns>
     IEnumerable<string> GetStatements(string sql);
+
+    void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception);
 }

--- a/src/grate.core/Migration/IDbMigrator.cs
+++ b/src/grate.core/Migration/IDbMigrator.cs
@@ -25,7 +25,7 @@ internal interface IDbMigrator : IAsyncDisposable, ICloneable
     Task OpenAdminConnection();
     Task CloseAdminConnection();
 
-    Task<bool> RunSql(string sql, string scriptName, MigrationType migrationType, long versionId,
+    Task<bool> RunSql(string sql, string scriptName, MigrationsFolder folder, long versionId,
         GrateEnvironment? environment,
         ConnectionType connectionType, TransactionHandling transactionHandling);
 

--- a/src/grate.mariadb/Infrastructure/MariaDbScriptFailed.cs
+++ b/src/grate.mariadb/Infrastructure/MariaDbScriptFailed.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using grate.Configuration;
+using grate.Exceptions;
+using MySqlConnector;
+
+namespace grate.MariaDb.Infrastructure;
+
+public class MariaDbScriptFailed: ScriptFailed
+{
+    public MariaDbScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception cause) 
+        : base(folder, file, scriptText, cause)
+    {
+    }
+    
+    protected override (int? line, int position) LineAndPosition => (0, 0);
+    protected override string? ErrorSnippet => null;
+
+    protected override int Position => this.DbException is MySqlException mySqlException
+        ? mySqlException.Number
+        : 0;
+
+    protected override IDictionary<string, object?>  GetDbScriptErrors()
+        => InnerException!.Data 
+            .Cast<DictionaryEntry>()
+            .ToDictionary(entry => entry.Key.ToString()!, entry => entry.Value);
+    
+}

--- a/src/grate.mariadb/Migration/MariaDbDatabase.cs
+++ b/src/grate.mariadb/Migration/MariaDbDatabase.cs
@@ -1,5 +1,7 @@
 ﻿using System.Data.Common;
 using System.Diagnostics;
+using grate.Configuration;
+using grate.Exceptions;
 using grate.Infrastructure;
 using grate.MariaDb.Infrastructure;
 using grate.Migration;
@@ -68,5 +70,10 @@ FROM information_schema.processlist WHERE DB = '{DatabaseName}'";
 
         var databaseExists = await DatabaseExists();
         Debug.Assert(!databaseExists, "Database still exists after it is dropped");
+    }
+
+    public override void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception)
+    {
+        throw new MariaDbScriptFailed(folder, file, scriptText, exception);
     }
 }

--- a/src/grate.oracle/Infrastructure/OracleScriptFailed.cs
+++ b/src/grate.oracle/Infrastructure/OracleScriptFailed.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using grate.Configuration;
+using grate.Exceptions;
+using Oracle.ManagedDataAccess.Client;
+
+namespace grate.oracle.Infrastructure;
+
+public class OracleScriptFailed: ScriptFailed
+{
+    public OracleScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception cause) 
+        : base(folder, file, scriptText, cause)
+    {
+    }
+
+    protected override IDictionary<string, object?> GetDbScriptErrors()
+        => GatherDetails(this.DbException as OracleException);
+    
+    protected override int Position => this.DbException is OracleException oracleException
+        ? oracleException.Errors[0]?.ParseErrorOffset ?? 0
+        : 0;
+    
+
+    private IDictionary<string, object?> GatherDetails(OracleException? ex)
+    {
+        return ex is null 
+            ? new Dictionary<string, object?>() 
+            : new Dictionary<string, object?>()
+            {
+                { nameof(OracleException.Message), ex.Message },
+                { nameof(OracleError.ParseErrorOffset), ex.Errors[0]?.ParseErrorOffset },
+                { nameof(OracleException.Number), ex.Number },
+                { nameof(OracleException.Procedure), ex.Procedure },
+                { nameof(OracleException.DataSource), ex.DataSource },
+                { nameof(OracleException.Source), ex.Source },
+                { nameof(OracleException.ErrorCode), ex.ErrorCode },
+                { nameof(OracleException.IsTransient), ex.IsTransient },
+                { nameof(OracleException.HelpLink), ex.HelpLink },
+                { nameof(OracleException.HResult), ex.HResult },
+                { nameof(OracleException.StackTrace), ex.StackTrace }
+            };
+    }
+    
+}

--- a/src/grate.oracle/Migration/OracleDatabase.cs
+++ b/src/grate.oracle/Migration/OracleDatabase.cs
@@ -3,8 +3,10 @@ using System.Data.Common;
 using System.Security.Claims;
 using Dapper;
 using grate.Configuration;
+using grate.Exceptions;
 using grate.Infrastructure;
 using grate.Migration;
+using grate.oracle.Infrastructure;
 using grate.Oracle.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Oracle.ManagedDataAccess.Client;
@@ -159,21 +161,8 @@ RETURNING id into :id
     private static string? GetValue(IDictionary<string, string?> dictionary, string key) =>
         dictionary.TryGetValue(key, out string? value) ? value : null;
 
-    //     private async Task CreateIdSequence(string table)
-    //     {
-    //         var sql = $"CREATE SEQUENCE {table}_seq";
-    //         await ExecuteNonQuery(ActiveConnection, sql, Config?.CommandTimeout);
-    //     }
-
-    //     private async Task CreateIdInsertTrigger(string table)
-    //     {
-    //         var sql = $@"
-    // CREATE OR REPLACE TRIGGER {table}_ins
-    // BEFORE INSERT ON {table}
-    // FOR EACH ROW
-    // BEGIN
-    //   SELECT {table}_seq.nextval INTO :new.id FROM dual;
-    // END;";
-    //         await ExecuteNonQuery(ActiveConnection, sql, Config?.CommandTimeout);
-    //     }
+    public override void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception)
+    {
+        throw new OracleScriptFailed(folder, file, scriptText, exception);
+    }
 }

--- a/src/grate.postgresql/Infrastructure/PostgreSqlScriptFailed.cs
+++ b/src/grate.postgresql/Infrastructure/PostgreSqlScriptFailed.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using grate.Configuration;
+using grate.Exceptions;
+using Npgsql;
+
+namespace grate.postgresql.Infrastructure;
+
+public class PostgreSqlScriptFailed: ScriptFailed
+{
+    public PostgreSqlScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception cause) 
+        : base(folder, file, scriptText, cause)
+    {
+    }
+    
+    protected override int Position => this.DbException is PostgresException postgresException
+        ? postgresException.Position
+        : 0;
+
+    protected override string? InnerExceptionMessage => DbException is PostgresException postgresException
+        ? $"{postgresException.SqlState}: {postgresException.MessageText}"
+        : InnerException?.Message;
+
+    protected override IDictionary<string, object?>  GetDbScriptErrors()
+        => InnerException!.Data 
+            .Cast<DictionaryEntry>()
+            .ToDictionary(entry => entry.Key.ToString()!, entry => entry.Value);
+    
+}

--- a/src/grate.postgresql/Migration/PostgreSqlDatabase.cs
+++ b/src/grate.postgresql/Migration/PostgreSqlDatabase.cs
@@ -1,7 +1,10 @@
 ﻿using System.Data.Common;
+using grate.Configuration;
+using grate.Exceptions;
 using grate.Infrastructure;
 using grate.Infrastructure.Npgsql;
 using grate.Migration;
+using grate.postgresql.Infrastructure;
 using grate.PostgreSql.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -29,4 +32,10 @@ public record PostgreSqlDatabase : AnsiSqlDatabase
 
     public override IEnumerable<string> GetStatements(string sql)
         => ReflectionNpgsqlQueryParser.Split(sql);
+
+
+    public override void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception)
+    {
+        throw new PostgreSqlScriptFailed(folder, file, scriptText, exception);
+    }
 }

--- a/src/grate.sqlite/Infrastructure/SqliteScriptFailed.cs
+++ b/src/grate.sqlite/Infrastructure/SqliteScriptFailed.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Data.Common;
+using grate.Configuration;
+using grate.Exceptions;
+using Microsoft.Data.Sqlite;
+
+namespace grate.sqlite.Infrastructure;
+
+public class SqliteScriptFailed: ScriptFailed
+{
+    public SqliteScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception cause) 
+        : base(folder, file, scriptText, cause)
+    {
+    }
+
+    protected override IDictionary<string, object?> GetDbScriptErrors()
+        => GatherDetails(DbException as SqliteException);
+    
+    protected override int Position => this.DbException is SqliteException sqliteException
+        ? sqliteException.ErrorCode
+        : 0;
+
+    protected override string? ErrorSnippet => null;
+
+
+    private IDictionary<string, object?> GatherDetails(SqliteException? ex)
+    {
+        return ex is null  
+            ? new Dictionary<string, object?>()
+            : new Dictionary<string, object?>()
+            {
+                { nameof(SqliteException.Message), ex.Message },
+                { nameof(SqliteException.Source), ex.Source },
+                { nameof(SqliteException.SqliteErrorCode), ex.SqliteErrorCode },
+                { nameof(SqliteException.SqliteExtendedErrorCode), ex.SqliteExtendedErrorCode },
+                { nameof(SqliteException.IsTransient), ex.IsTransient },
+                { nameof(SqliteException.HelpLink), ex.HelpLink },
+                { nameof(SqliteException.HResult), ex.HResult },
+                { nameof(SqliteException.StackTrace), ex.StackTrace }
+            };
+    }
+}

--- a/src/grate.sqlite/Migration/SqLiteDatabase.cs
+++ b/src/grate.sqlite/Migration/SqLiteDatabase.cs
@@ -1,6 +1,9 @@
 ﻿using System.Data.Common;
+using grate.Configuration;
+using grate.Exceptions;
 using grate.Infrastructure;
 using grate.Migration;
+using grate.sqlite.Infrastructure;
 using grate.Sqlite.Infrastructure;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
@@ -64,5 +67,10 @@ WHERE name='{columnName}'";
     public override Task RestoreDatabase(string backupPath)
     {
         throw new System.NotImplementedException("Restoring a database from file is not currently supported for  SqlLite.");
+    }
+
+    public override void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception)
+    {
+        throw new SqliteScriptFailed(folder, file, scriptText, exception);
     }
 }

--- a/src/grate.sqlserver/Infrastructure/SqlServerScriptFailed.cs
+++ b/src/grate.sqlserver/Infrastructure/SqlServerScriptFailed.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections;
+using grate.Configuration;
+using grate.Exceptions;
+using Microsoft.Data.SqlClient;
+
+namespace grate.sqlserver.Infrastructure;
+
+public class SqlServerScriptFailed: ScriptFailed
+{
+    public SqlServerScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception cause) 
+        : base(folder, file, scriptText, cause)
+    {
+    }
+    
+    protected override IDictionary<string, object?> GetDbScriptErrors()
+        => GatherDetails(SqlException);
+
+    private SqlException? SqlException => DbException as SqlException;
+
+    //protected override int Position => this.SqlException!.LineNumber
+
+    protected override (int? line, int position) LineAndPosition => (
+        SqlException!.LineNumber > 0 ? SqlException.LineNumber - 1 : 0, 0);
+
+
+    private IDictionary<string, object?> GatherDetails(SqlException? ex)
+    {
+        return DbException is null 
+            ? new Dictionary<string, object?>()
+            : new Dictionary<string, object?>()
+            {
+                { nameof(SqlException.Message), ex!.Message },
+                { nameof(SqlException.LineNumber), ex.LineNumber },
+                { nameof(SqlException.Number), ex.Number },
+                { nameof(SqlException.Procedure), ex.Procedure },
+                { nameof(SqlException.Server), ex.Server },
+                { nameof(SqlException.Source), ex.Source },
+                { nameof(SqlException.State), ex.State },
+                { nameof(SqlException.ClientConnectionId), ex.ClientConnectionId },
+                { nameof(SqlException.Class), ex.Class },
+                { nameof(SqlException.ErrorCode), ex.ErrorCode },
+                { nameof(SqlException.SqlState), ex.State },
+                { nameof(SqlException.IsTransient), ex.IsTransient },
+                { nameof(SqlException.HelpLink), ex.HelpLink },
+                { nameof(SqlException.HResult), ex.HResult },
+                { nameof(SqlException.StackTrace), ex.StackTrace } 
+            };
+    }
+    
+}

--- a/src/grate.sqlserver/Migration/SqlServerDatabase.cs
+++ b/src/grate.sqlserver/Migration/SqlServerDatabase.cs
@@ -1,8 +1,10 @@
 ﻿using System.Data.Common;
 using System.Transactions;
 using grate.Configuration;
+using grate.Exceptions;
 using grate.Infrastructure;
 using grate.Migration;
+using grate.sqlserver.Infrastructure;
 using grate.SqlServer.Infrastructure;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
@@ -120,4 +122,10 @@ public record SqlServerDatabase : AnsiSqlDatabase
         $@"
 SELECT 1 FROM  {ScriptsRunTable} WITH (NOLOCK)
 WHERE script_name = @scriptName";
+
+
+    public override void ThrowScriptFailed(MigrationsFolder folder, string file, string? scriptText, Exception exception)
+    {
+        throw new SqlServerScriptFailed(folder, file, scriptText, exception);
+    }
 }

--- a/src/grate/Infrastructure/GrateConsoleFormatter.cs
+++ b/src/grate/Infrastructure/GrateConsoleFormatter.cs
@@ -50,11 +50,11 @@ internal class GrateConsoleFormatter : ConsoleFormatter, IDisposable
         LogLevel logLevel = logEntry.LogLevel;
         ConsoleColors logLevelColors = GetLogLevelConsoleColors(logLevel);
 
-        textWriter.WriteColoredMessageLine(message, logLevelColors.Foreground);
+        textWriter.WriteColoredMessageLine(message, logLevelColors.Foreground, logLevelColors.Background);
 
         if (exception != null)
         {
-            textWriter.WriteColoredMessageLine(exception.ToString(), logLevelColors.Foreground);
+            textWriter.WriteColoredMessageLine(exception.ToString(), logLevelColors.Foreground, logLevelColors.Background);
         }
         textWriter.Flush();
     }
@@ -76,21 +76,17 @@ internal class GrateConsoleFormatter : ConsoleFormatter, IDisposable
             LogLevel.Debug => new ConsoleColors(GrateConsoleColor.Foreground.DarkGray),
             LogLevel.Information => new ConsoleColors(GrateConsoleColor.Foreground.Green),
             LogLevel.Warning => new ConsoleColors(GrateConsoleColor.Foreground.Yellow),
-            LogLevel.Error => new ConsoleColors(GrateConsoleColor.Foreground.Black),
-            LogLevel.Critical => new ConsoleColors(GrateConsoleColor.Foreground.White),
+            LogLevel.Error => new ConsoleColors(GrateConsoleColor.Foreground.DarkRed),
+            LogLevel.Critical => new ConsoleColors(GrateConsoleColor.Foreground.Cyan),
             _ => ConsoleColors.None
         };
     }
 
 
-    private readonly struct ConsoleColors
+    private readonly struct ConsoleColors(GrateConsoleColor foreground, GrateConsoleColor? background = null)
     {
-        public ConsoleColors(GrateConsoleColor foreground)
-        {
-            Foreground = foreground;
-        }
-
-        public GrateConsoleColor Foreground { get; }
+        public GrateConsoleColor Foreground { get; } = foreground;
+        public GrateConsoleColor? Background { get; } = background;
 
         public static ConsoleColors None => new();
     }

--- a/src/grate/Infrastructure/TextWriterExtensions.cs
+++ b/src/grate/Infrastructure/TextWriterExtensions.cs
@@ -4,30 +4,32 @@ internal static class TextWriterExtensions
 {
     private static bool? _supportsAnsiColors;
 
-    public static void WriteColoredMessage(this TextWriter textWriter, string message, GrateConsoleColor foreground)
+    public static void WriteColoredMessage(this TextWriter textWriter, string message, GrateConsoleColor foreground,
+        GrateConsoleColor? background = null)
     {
-        SetColorsIfEnabled(textWriter, foreground);
+        SetColorsIfEnabled(textWriter, foreground, background);
         textWriter.Write(message);
         ResetColorsIfEnabled(textWriter);
     }
-
-    public static void WriteColoredMessageLine(this TextWriter textWriter, string? message, GrateConsoleColor foreground)
+        
+    public static void WriteColoredMessageLine(this TextWriter textWriter, string? message,
+        GrateConsoleColor foreground, GrateConsoleColor? background = null)
     {
-        SetColorsIfEnabled(textWriter, foreground);
+        SetColorsIfEnabled(textWriter, foreground, background);
         textWriter.WriteLine(message);
         ResetColorsIfEnabled(textWriter);
     }
-
-
-    private static void SetColorsIfEnabled(TextWriter textWriter, GrateConsoleColor foreground)
+        
+            
+    private static void SetColorsIfEnabled(TextWriter textWriter, GrateConsoleColor foreground, GrateConsoleColor? background = null)
     {
         if (!DisableAnsiColors)
         {
-            SetColors(textWriter, foreground.AnsiColorCode);
+            SetColors(textWriter, foreground.AnsiColorCode, background?.AnsiColorCode);
         }
     }
 
-
+        
     private static void ResetColorsIfEnabled(TextWriter textWriter)
     {
         if (!DisableAnsiColors)
@@ -35,25 +37,30 @@ internal static class TextWriterExtensions
             ResetColors(textWriter);
         }
     }
-
+        
     private static void ResetColors(TextWriter textWriter)
     {
         textWriter.Write(GrateConsoleColor.Foreground.Default.AnsiColorCode); // reset to default foreground color
+        //textWriter.Write(GrateConsoleColor.Background.Default.AnsiColorCode); // reset to the background color
     }
 
-    private static void SetColors(TextWriter textWriter, string foregroundColorAnsiCode)
+    private static void SetColors(TextWriter textWriter, string foregroundColorAnsiCode, string? backgroundColorAnsiCode = null)
     {
+        if (backgroundColorAnsiCode != null)
+        {
+            textWriter.Write(backgroundColorAnsiCode);
+        }
         textWriter.Write(foregroundColorAnsiCode);
     }
 
     private static bool DisableAnsiColors => !SupportsAnsiColors || Console.IsOutputRedirected;
-
+        
     private static bool SupportsAnsiColors => _supportsAnsiColors ??= GetSupportsAnsiColors();
 
     private static bool GetSupportsAnsiColors()
     {
         try
-        // Calling Console.GetCursorPosition() sometimes fails if the console has not been written to yet
+            // Calling Console.GetCursorPosition() sometimes fails if the console has not been written to yet
         {
             lock (Console.Out)
             {

--- a/unittests/Basic_tests/Infrastructure/MockDbMigrator.cs
+++ b/unittests/Basic_tests/Infrastructure/MockDbMigrator.cs
@@ -75,7 +75,7 @@ public class MockDbMigrator: IDbMigrator
         throw new NotImplementedException();
     }
 
-    public Task<bool> RunSql(string sql, string scriptName, MigrationType migrationType, long versionId, GrateEnvironment? environment,
+    public Task<bool> RunSql(string sql, string scriptName, MigrationsFolder folder, long versionId, GrateEnvironment? environment,
         ConnectionType connectionType, TransactionHandling transactionHandling)
     {
         return Task.FromResult(false);

--- a/unittests/MariaDB/Running_MigrationScripts/Failing_Scripts.cs
+++ b/unittests/MariaDB/Running_MigrationScripts/Failing_Scripts.cs
@@ -8,5 +8,17 @@ namespace MariaDB.Running_MigrationScripts;
 public class Failing_Scripts(IGrateTestContext testContext, ITestOutputHelper testOutput)
     : TestCommon.Generic.Running_MigrationScripts.Failing_Scripts(testContext, testOutput)
 {
-    protected override string ExpectedErrorMessageForInvalidSql => "Unknown column 'TOP' in 'field list'";
+    protected override string ExpectedErrorMessageForInvalidSql => 
+        """
+        Update ("up"):
+        --------------------------------------------------------------------------------
+        2_failing.sql: Unknown column 'TOP' in 'field list'
+        """;
+    
+
+    protected override IDictionary<string, object?> ExpectedErrorDetails => new Dictionary<string, object?>
+    {
+        {"Server Error Code", 1054},
+        {"SqlState", "42S22"}
+    };
 }

--- a/unittests/MariaDB/TestInfrastructure/MariaDbTestContainer.cs
+++ b/unittests/MariaDB/TestInfrastructure/MariaDbTestContainer.cs
@@ -23,6 +23,7 @@ public class MariaDbTestContainer : ContainerFixture
             .WithImage(DockerImage)
             .WithPassword(AdminPassword)
             .WithPortBinding(Port, true)
+            .WithCommand("--max_connections=10000")
             .Build();
     }
 }

--- a/unittests/Oracle/Running_MigrationScripts/Failing_Scripts.cs
+++ b/unittests/Oracle/Running_MigrationScripts/Failing_Scripts.cs
@@ -7,5 +7,25 @@ public class Failing_Scripts(IGrateTestContext testContext, ITestOutputHelper te
     : TestCommon.Generic.Running_MigrationScripts.Failing_Scripts(testContext, testOutput)
 {
     protected override string ExpectedErrorMessageForInvalidSql =>
-        @"ORA-00923: FROM keyword not found where expected";
+        """
+        Update ("up"):
+        --------------------------------------------------------------------------------
+        2_failing.sql: ORA-00923: FROM keyword not found where expected
+        (0,10): SELECT TOP
+                         ^ ORA-00923: FROM keyword not found where expected
+        """;
+
+    protected override IDictionary<string, object?> ExpectedErrorDetails => new Dictionary<string, object?>
+    {
+        {"Message", "ORA-00923: FROM keyword not found where expected"},
+        {"ParseErrorOffset", 10},
+        {"Number", 923},
+        {"Procedure", ""},
+        {"DataSource", ""},
+        {"Source", "Oracle Data Provider for .NET, Managed Driver"},
+        {"ErrorCode", -2147467259},
+        {"IsTransient", false},
+        {"HelpLink", null},
+        {"HResult", -2147467259},
+    };
 }

--- a/unittests/PostgreSQL/Running_MigrationScripts/Failing_Scripts.cs
+++ b/unittests/PostgreSQL/Running_MigrationScripts/Failing_Scripts.cs
@@ -7,8 +7,26 @@ namespace PostgreSQL.Running_MigrationScripts;
 public class Failing_Scripts(IGrateTestContext testContext, ITestOutputHelper testOutput)
     : TestCommon.Generic.Running_MigrationScripts.Failing_Scripts(testContext, testOutput)
 {
-    protected override string ExpectedErrorMessageForInvalidSql =>
-        @"42703: column ""top"" does not exist
+    
+    protected override string ExpectedErrorMessageForInvalidSql => 
+        """
+        Update ("up"):
+        --------------------------------------------------------------------------------
+        2_failing.sql: 42703: column "top" does not exist
+        (0,8): SELECT TOP
+                      ^ 42703: column "top" does not exist
+        """;
+    
 
-POSITION: 8";
+    protected override IDictionary<string, object?> ExpectedErrorDetails => new Dictionary<string, object?>
+    {
+        {"Severity", "ERROR"},
+        {"InvariantSeverity", "ERROR"},
+        {"SqlState", "42703"},
+        {"MessageText", "column \"top\" does not exist"},
+        {"Position", 8},
+        {"File", "parse_relation.c"},
+        {"Line", "3713"},
+        {"Routine", "errorMissingColumn"}
+    };
 }

--- a/unittests/SqlServer/Running_MigrationScripts/Failing_Scripts.cs
+++ b/unittests/SqlServer/Running_MigrationScripts/Failing_Scripts.cs
@@ -7,5 +7,33 @@ namespace SqlServer.Running_MigrationScripts;
 public class Failing_Scripts(IGrateTestContext testContext, ITestOutputHelper testOutput)
     : TestCommon.Generic.Running_MigrationScripts.Failing_Scripts(testContext, testOutput)
 {
-    protected override string ExpectedErrorMessageForInvalidSql => "Incorrect syntax near 'TOP'.";
+
+    protected override string ExpectedErrorMessageForInvalidSql =>
+        """
+        Update ("up"):
+        --------------------------------------------------------------------------------
+        2_failing.sql: Incorrect syntax near 'TOP'.
+        (0,0): SELECT TOP
+              ^ Incorrect syntax near 'TOP'.
+        """;
+
+
+    protected override IDictionary<string, object?> ExpectedErrorDetails => new Dictionary<string, object?>
+    { 
+        { "Message", "Incorrect syntax near \u0027TOP\u0027." },
+        { "LineNumber", 1 },
+        { "Number", 102 },
+        { "Procedure", "" },
+        //{ "Server", "localhost,59557" },
+        { "Source", "Core Microsoft SqlClient Data Provider" },
+        { "State", 1 },
+        //{ "ClientConnectionId", "609b30bb-8410-43e7-93d8-69c84525c6cb" },
+        { "Class", 15 },
+        { "ErrorCode", -2146232060 },
+        { "SqlState", 1 },
+        { "IsTransient", false },
+        { "HelpLink", null },
+        { "HResult", -2146232060 },
+    }; 
+
 }

--- a/unittests/SqlServerCaseSensitive/Running_MigrationScripts/Failing_Scripts.cs
+++ b/unittests/SqlServerCaseSensitive/Running_MigrationScripts/Failing_Scripts.cs
@@ -6,5 +6,30 @@ namespace SqlServerCaseSensitive.Running_MigrationScripts;
 public class Failing_Scripts(IGrateTestContext testContext, ITestOutputHelper testOutput)
     : TestCommon.Generic.Running_MigrationScripts.Failing_Scripts(testContext, testOutput)
 {
-    protected override string ExpectedErrorMessageForInvalidSql => "Incorrect syntax near 'TOP'.";
+    protected override string ExpectedErrorMessageForInvalidSql =>
+        """
+        Update ("up"):
+        --------------------------------------------------------------------------------
+        2_failing.sql: Incorrect syntax near 'TOP'.
+        (0,0): SELECT TOP
+              ^ Incorrect syntax near 'TOP'.
+        """;
+
+    protected override IDictionary<string, object?> ExpectedErrorDetails => new Dictionary<string, object?>
+    { 
+        { "Message", "Incorrect syntax near \u0027TOP\u0027." },
+        { "LineNumber", 1 },
+        { "Number", 102 },
+        { "Procedure", "" },
+        { "Server", "localhost,59557" },
+        { "Source", "Core Microsoft SqlClient Data Provider" },
+        { "State", 1 },
+        { "ClientConnectionId", "609b30bb-8410-43e7-93d8-69c84525c6cb" },
+        { "Class", 15 },
+        { "ErrorCode", -2146232060 },
+        { "SqlState", 1 },
+        { "IsTransient", false },
+        { "HelpLink", null },
+        { "HResult", -2146232060 },
+    };
 }

--- a/unittests/Sqlite/Running_MigrationScripts/Failing_Scripts.cs
+++ b/unittests/Sqlite/Running_MigrationScripts/Failing_Scripts.cs
@@ -9,5 +9,27 @@ namespace Sqlite.Running_MigrationScripts;
 public class Failing_Scripts(IGrateTestContext testContext, ITestOutputHelper testOutput)
     : TestCommon.Generic.Running_MigrationScripts.Failing_Scripts(testContext, testOutput)
 {
-    protected override string ExpectedErrorMessageForInvalidSql => "SQLite Error 1: 'no such column: TOP'.";
+    protected override string ExpectedErrorMessageForInvalidSql => 
+        """
+        Update ("up"):
+        --------------------------------------------------------------------------------
+        2_failing.sql: SQLite Error 1: 'no such column: TOP'.
+        """;
+
+    // Sqlite does not provide the error detail in the Data collection as other databases do.
+    // And, the error message basically contains all the details that are available as other properties
+    // on the exception. So extracting a dictionary from explicit SqliteException properties does
+    // not give us any more information than the message itself.
+    protected override IDictionary<string, object?> ExpectedErrorDetails => new Dictionary<string, object?>()
+    {
+        { "Message", "SQLite Error 1: \u0027no such column: TOP\u0027." },
+        { "Source", "Microsoft.Data.Sqlite" },
+        { "SqliteErrorCode", 1 },
+        { "SqliteExtendedErrorCode", 1 },
+        { "IsTransient", false },
+        { "HelpLink", null },
+        { "HResult", -2147467259 },
+    };
+
+
 }

--- a/unittests/TestCommon/Generic/Running_MigrationScripts/One_time_scripts.cs
+++ b/unittests/TestCommon/Generic/Running_MigrationScripts/One_time_scripts.cs
@@ -76,7 +76,9 @@ public abstract class One_time_scripts(IGrateTestContext context, ITestOutputHel
 
         await using (var migrator = Context.Migrator.WithConfiguration(config))
         {
-            await Assert.ThrowsAsync<OneTimeScriptChanged>(() => migrator.Migrate());
+            var ex = await Assert.ThrowsAsync<MigrationFailed>(() => migrator.Migrate());
+            var inner = ex.InnerException;
+            inner.Should().BeOfType<OneTimeScriptChanged>();
         }
 
         string[] scripts;

--- a/unittests/TestCommon/TestInfrastructure/SqlStatements.cs
+++ b/unittests/TestCommon/TestInfrastructure/SqlStatements.cs
@@ -3,7 +3,7 @@
 public record SqlStatements
 {
     public string SelectVersion { get; init; } = default!;
-    public string SleepTwoSeconds { get; init; } = default!;
+    public string? SleepTwoSeconds { get; init; }
     public Func<string?, string?, string?, string?> CreateUser { get; init; } = (_ , _, _) => null;
     public Func<string?, string?, string?> GrantAccess { get; init; } = (_, _) => null;
     public string LineComment { get; init; } = "--";


### PR DESCRIPTION
* Fixed error output to not include stack trace, except with log level debug
* Output the file that fails on errors agains the database
* Added line number and position on the error (doesn't work on all databases - dependent on the level of error details the database client libraries provide)