### PR TITLE
Chore: Remove 'CommandLine.' prefix from command-line tests to improve readibility of step names in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,11 +325,11 @@ jobs:
       # and cheap, for each one.
       matrix:
         category:
-          - CommandLine.SqlServer
-          - CommandLine.PostgreSQL
-          - CommandLine.MariaDB
-          - CommandLine.Sqlite
-          - CommandLine.Oracle
+          - SqlServer
+          - PostgreSQL
+          - MariaDB
+          - Sqlite
+          - Oracle
         os:
         # We can only run tests on Linux for now, until we start the database separately somewhere (azure, something)
         # and run against an external database. Because the commandline tests are also for now _dependent_ on
@@ -369,8 +369,8 @@ jobs:
     - name: Test
       run: >
         dotnet test
-        unittests/CommandLine/${{ matrix.category }}
-        --logger:"xunit;LogFilePath=/tmp/test-results/${{ matrix.os.arch }}/${{ matrix.category }}.xml" --
+        unittests/CommandLine/CommandLine.${{ matrix.category }}
+        --logger:"xunit;LogFilePath=/tmp/test-results/${{ matrix.os.arch }}/CommandLine.${{ matrix.category }}.xml" --
         -MaxCpuCount 2
       env:
         LogLevel: Warning


### PR DESCRIPTION
Chore: Remove 'CommandLine.' prefix from command-line tests to improve readibility of step names in GitHub actions