### PR TITLE
Dog-fooding: Use grate to version grate tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
      runs-on: ubuntu-latest
      name: Create test report
      needs: test
+     if: always()
 
      steps:
       - name: Download XML test reports
@@ -113,7 +114,7 @@ jobs:
       - name: Install smink
         run: |
           BASEURL="https://github.com/erikbra/smink/releases/download/"
-          VERSION="0.2.0"
+          VERSION="0.3.0"
 
           INSTALL_DIR="/tmp/smink"
           SMINK="${INSTALL_DIR}/smink"

--- a/.gitignore
+++ b/.gitignore
@@ -358,4 +358,5 @@ MigrationBackup/
 
 .DS_Store
 .envrc
+.mono
 *.tfstate

--- a/src/grate.core/Configuration/GrateConfiguration.cs
+++ b/src/grate.core/Configuration/GrateConfiguration.cs
@@ -155,4 +155,8 @@ public record GrateConfiguration
     /// </summary>
     public bool IgnoreDirectoryNames { get; set; }
 
+    /// <summary>
+    /// Defer writing to the run tables until the end of the migration (only used in bootstrapping)
+    /// </summary>
+    internal bool DeferWritingToRunTables { get; set; }
 }

--- a/src/grate.core/Exceptions/ScriptFailed.cs
+++ b/src/grate.core/Exceptions/ScriptFailed.cs
@@ -60,7 +60,7 @@ public abstract class ScriptFailed: MigrationException
             
             if (ScriptText is { })
             {
-                for (var i = 0; i < Position; i++)
+                for (var i = 0; i < Position && i < ScriptText.Length; i++)
                 {
                     if (ScriptText[i] == '\n')
                     {

--- a/src/grate.core/Infrastructure/Bootstrapping.cs
+++ b/src/grate.core/Infrastructure/Bootstrapping.cs
@@ -1,0 +1,55 @@
+﻿using System.Text.RegularExpressions;
+
+namespace grate.Infrastructure;
+
+internal static class Bootstrapping
+{
+    internal static async Task WriteBootstrapScriptsToFolder(
+        Type databasetype, 
+        string folder,
+        string resourcePrefix,
+        string? sqlFolderNamePrefix)
+    {
+        var assembly = databasetype.Assembly;
+        
+        // If the resource prefix starts with a number, we need to prefix it with an underscore
+        if (Regex.IsMatch(resourcePrefix, "^\\d"))
+        {
+            resourcePrefix = $"_{resourcePrefix}";
+        }
+        
+        var prefix = $"{assembly.GetName().Name}.Bootstrapping.Sql.{resourcePrefix}";
+        var prefixLength = prefix.Length;
+        
+        var resources = assembly.GetManifestResourceNames()
+            .Where(x => x.StartsWith(prefix))
+            .ToArray();
+
+        foreach (var resource in resources)
+        {
+            var nextDot = resource.IndexOf('.', prefixLength + 1);
+            var folderName = resource.Substring(prefixLength + 1, nextDot - prefixLength - 1);
+            
+            var fullFolder = sqlFolderNamePrefix is {} 
+                ? Path.Combine(folder, folderName, sqlFolderNamePrefix)
+                : Path.Combine(folder, folderName);
+            if (!Directory.Exists(fullFolder))
+            {
+                Directory.CreateDirectory(fullFolder);
+            }
+            
+            var resourceName = resource.Substring(prefixLength + 1 + folderName.Length + 1);
+            var resourceStream = assembly.GetManifestResourceStream(resource);
+            if (resourceStream is null)
+            {
+                throw new Exception($"Resource {resource} not found");
+            }
+
+            using var streamReader = new StreamReader(resourceStream);
+            var resourceText = await streamReader.ReadToEndAsync();
+            var filePath = Path.Combine(fullFolder, resourceName);
+            await File.WriteAllTextAsync(filePath, resourceText);
+        }
+    }
+    
+}

--- a/src/grate.core/Infrastructure/GrateEnvironment.cs
+++ b/src/grate.core/Infrastructure/GrateEnvironment.cs
@@ -21,4 +21,9 @@ public record GrateEnvironment(string Current)
     private static string FileName(string path) => new FileInfo(path).Name;
 
     public override string ToString() => Current;
+    
+    // The names are so difficult to make sure there is a close to zero chance that we collide with any 
+    // environment that an actual user might use (which would make things crash badly)
+    public static GrateEnvironment Internal { get; } = new("GrateInternal-a01ce6e6-0038-4ebe-959e-7d039f6435bf");
+    public static GrateEnvironment InternalBootstrap { get; } = new("GrateInternalBoostrap-a61456d0-e00a-4933-b692-c6a5d7d51539");
 }

--- a/src/grate.core/Migration/DbMigrator.cs
+++ b/src/grate.core/Migration/DbMigrator.cs
@@ -49,7 +49,6 @@ internal record DbMigrator : IDbMigrator
     public Task<IDisposable> OpenNewActiveConnection() => Database.OpenNewActiveConnection();
     public Task OpenActiveConnection() => Database.OpenActiveConnection();
 
-    public Task RunSupportTasks() => Database.RunSupportTasks();
     public Task<string> GetCurrentVersion() => Database.GetCurrentVersion();
     public Task<long> VersionTheDatabase(string newVersion)
     {
@@ -408,5 +407,5 @@ internal record DbMigrator : IDbMigrator
         GC.SuppressFinalize(this);
     }
 
-    object ICloneable.Clone() => this with { };
+    object ICloneable.Clone() => this with { Database = (IDatabase) Database.Clone() };
 }

--- a/src/grate.core/Migration/FileSystem.cs
+++ b/src/grate.core/Migration/FileSystem.cs
@@ -20,4 +20,18 @@ internal static class FileSystem
                         GetFileNameWithoutExtension(f.FullName)),
                     CurrentCultureIgnoreCase);
     }
+    
+    public static DirectoryInfo CreateRandomTempDirectory()
+    {
+        var dummyFile = Path.GetTempFileName();
+        File.Delete(dummyFile);
+
+        if (Directory.Exists(dummyFile))
+        {
+            Directory.Delete(dummyFile, true);
+        }
+
+        var scriptsDir = Directory.CreateDirectory(dummyFile);
+        return scriptsDir;
+    }
 }

--- a/src/grate.core/Migration/IDatabase.cs
+++ b/src/grate.core/Migration/IDatabase.cs
@@ -3,7 +3,7 @@ using grate.Configuration;
 
 namespace grate.Migration;
 
-public interface IDatabase : IAsyncDisposable
+public interface IDatabase : IAsyncDisposable, ICloneable
 {
     string? ServerName { get; }
     string? DatabaseName { get; }
@@ -33,7 +33,6 @@ public interface IDatabase : IAsyncDisposable
     Task DropDatabase();
 
     Task<bool> DatabaseExists();
-    Task RunSupportTasks();
     Task<string> GetCurrentVersion();
     Task<long> VersionTheDatabase(string newVersion);
     void Rollback();

--- a/src/grate.core/Migration/IDbMigrator.cs
+++ b/src/grate.core/Migration/IDbMigrator.cs
@@ -19,7 +19,6 @@ internal interface IDbMigrator : IAsyncDisposable, ICloneable
     Task<bool> DatabaseExists();
     Task OpenConnection();
     Task CloseConnection();
-    Task RunSupportTasks();
     Task<string> GetCurrentVersion();
     Task<long> VersionTheDatabase(string newVersion);
     Task OpenAdminConnection();

--- a/src/grate.mariadb/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE {{SchemaName}}_{{ScriptsRunTable}}(
+    id bigint NOT NULL AUTO_INCREMENT,
+    version_id BIGINT NULL,
+    script_name varchar(255) NULL,
+    text_of_script text NULL,
+    text_hash varchar(512) NULL,
+    one_time_script boolean NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by varchar(50) NULL,
+    CONSTRAINT PK_{{ScriptsRunTable}}_id PRIMARY KEY (id)
+)

--- a/src/grate.mariadb/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE {{SchemaName}}_{{ScriptsRunErrorsTable}}(
+    id bigint NOT NULL AUTO_INCREMENT,
+    repository_path varchar(255) NULL,
+    version varchar(50) NULL,
+    script_name varchar(255) NULL,
+    text_of_script text NULL,
+    erroneous_part_of_script text NULL,
+    error_message text NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by varchar(50) NULL,
+    CONSTRAINT PK_{{ScriptsRunErrorsTable}}_id PRIMARY KEY (id)
+)
+

--- a/src/grate.mariadb/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE {{SchemaName}}_{{VersionTable}}(
+    id bigint NOT NULL AUTO_INCREMENT,
+    repository_path varchar(255) NULL,
+    version varchar(50) NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by varchar(50) NULL,
+    status varchar(50) NULL,
+    CONSTRAINT PK_{{VersionTable}}_id PRIMARY KEY (id)
+)

--- a/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE {{SchemaName}}_{{VersionTable}}
+ADD COLUMN IF NOT EXISTS status varchar(50) NULL;

--- a/src/grate.mariadb/grate.mariadb.csproj
+++ b/src/grate.mariadb/grate.mariadb.csproj
@@ -16,4 +16,9 @@
   <ItemGroup>
     <None Include="NuGet.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Bootstrapping\Sql\**\*.sql" />
+    <None Remove="Bootstrapping\Sql\**\*.sql" />
+  </ItemGroup>
 </Project>

--- a/src/grate.oracle/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
+++ b/src/grate.oracle/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE {{SchemaName}}_{{ScriptsRunTable}}(
+    id NUMBER(19) GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
+    version_id NUMBER(19) NULL,
+    script_name VARCHAR2(255) NULL,
+    text_of_script CLOB NULL,
+    text_hash VARCHAR2(512) NULL,
+    one_time_script CHAR(1) NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by VARCHAR2(50) NULL
+)

--- a/src/grate.oracle/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
+++ b/src/grate.oracle/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE {{SchemaName}}_{{ScriptsRunErrorsTable}}(
+    id NUMBER(19) GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
+    repository_path VARCHAR2(255) NULL,
+    version VARCHAR2(50) NULL,
+    script_name VARCHAR2(255) NULL,
+    text_of_script CLOB NULL,
+    erroneous_part_of_script CLOB NULL,
+    error_message CLOB NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by VARCHAR2(50) NULL
+)
+

--- a/src/grate.oracle/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
+++ b/src/grate.oracle/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE {{SchemaName}}_{{VersionTable}}(
+    id NUMBER(19) GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
+    repository_path VARCHAR2(255) NULL,
+    version VARCHAR2(50) NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by VARCHAR2(50) NULL,
+    status VARCHAR2(50) NULL
+)

--- a/src/grate.oracle/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.oracle/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,0 +1,8 @@
+DECLARE
+    column_exists EXCEPTION;
+    PRAGMA EXCEPTION_INIT (column_exists , -01430);
+BEGIN
+    EXECUTE IMMEDIATE 'ALTER TABLE {{SchemaName}}_{{VersionTable}} ADD status VARCHAR2(50)';
+EXCEPTION 
+    WHEN column_exists THEN NULL;
+END;

--- a/src/grate.oracle/grate.oracle.csproj
+++ b/src/grate.oracle/grate.oracle.csproj
@@ -16,4 +16,9 @@
   <ItemGroup>
     <None Include="NuGet.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Bootstrapping\Sql\**\*.sql" />
+    <None Remove="Bootstrapping\Sql\**\*.sql" />
+  </ItemGroup>
 </Project>

--- a/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/01_create_schema_grate.ENV.GrateInternalBoostrap-a61456d0-e00a-4933-b692-c6a5d7d51539.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/01_create_schema_grate.ENV.GrateInternalBoostrap-a61456d0-e00a-4933-b692-c6a5d7d51539.sql
@@ -1,0 +1,3 @@
+-- We need to do 'if not exists' on this, as it is run twice, one for the Grate... tables,
+-- and one for the "standard" migration tables
+CREATE SCHEMA IF NOT EXISTS "{{SchemaName}}";

--- a/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "{{SchemaName}}"."{{ScriptsRunTable}}"(
+    id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+    version_id BIGINT NULL,
+    script_name varchar(255) NULL,
+    text_of_script text NULL,
+    text_hash varchar(512) NULL,
+    one_time_script boolean NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by varchar(50) NULL,
+    CONSTRAINT PK_{{ScriptsRunTable}}_id PRIMARY KEY (id)
+)

--- a/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "{{SchemaName}}"."{{ScriptsRunErrorsTable}}"(
+    id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+    repository_path varchar(255) NULL,
+    version varchar(50) NULL,
+    script_name varchar(255) NULL,
+    text_of_script text NULL,
+    erroneous_part_of_script text NULL,
+    error_message text NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by varchar(50) NULL,
+    CONSTRAINT PK_{{ScriptsRunErrorsTable}}_id PRIMARY KEY (id)
+)
+

--- a/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "{{SchemaName}}"."{{VersionTable}}"(
+    id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+    repository_path varchar(255) NULL,
+    version varchar(50) NULL,
+    entry_date timestamp NULL,
+    modified_date timestamp NULL,
+    entered_by varchar(50) NULL,
+    status varchar(50) NULL,
+    CONSTRAINT PK_{{VersionTable}}_id PRIMARY KEY (id)
+)

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "{{SchemaName}}"."{{VersionTable}}"
+ADD COLUMN IF NOT EXISTS status varchar(50) NULL;

--- a/src/grate.postgresql/Infrastructure/PostgreSqlSyntax.cs
+++ b/src/grate.postgresql/Infrastructure/PostgreSqlSyntax.cs
@@ -29,7 +29,7 @@ public readonly struct PostgreSqlSyntax : ISyntax
     public string DropDatabase(string databaseName) => @$"select pg_terminate_backend(pid) from pg_stat_activity where datname='{databaseName}';
                                                               COMMIT;
                                                               DROP DATABASE IF EXISTS ""{databaseName}"";";
-    public string TableWithSchema(string schemaName, string tableName) => $"{schemaName}.\"{tableName}\"";
+    public string TableWithSchema(string schemaName, string tableName) => $"\"{schemaName}\".\"{tableName}\"";
     public string ReturnId => "RETURNING id;";
     public string TimestampType => "timestamp";
     public string Quote(string text) => $"\"{text}\"";

--- a/src/grate.postgresql/grate.postgresql.csproj
+++ b/src/grate.postgresql/grate.postgresql.csproj
@@ -16,5 +16,10 @@
   <ItemGroup>
     <None Include="NuGet.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="Bootstrapping\Sql\**\*.sql" />
+    <None Remove="Bootstrapping\Sql\**\*.sql" />
+  </ItemGroup>
 
 </Project>

--- a/src/grate.sqlite/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
+++ b/src/grate.sqlite/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE {{SchemaName}}_{{ScriptsRunTable}}(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    version_id BIGINT NULL,
+    script_name nvarchar(255) NULL,
+    text_of_script ntext NULL,
+    text_hash nvarchar(512) NULL,
+    one_time_script bit NULL,
+    entry_date datetime NULL,
+    modified_date datetime NULL,
+    entered_by nvarchar(50) NULL
+)

--- a/src/grate.sqlite/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
+++ b/src/grate.sqlite/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE {{SchemaName}}_{{ScriptsRunErrorsTable}}(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repository_path nvarchar(255) NULL,
+    version nvarchar(50) NULL,
+    script_name nvarchar(255) NULL,
+    text_of_script ntext NULL,
+    erroneous_part_of_script ntext NULL,
+    error_message ntext NULL,
+    entry_date datetime NULL,
+    modified_date datetime NULL,
+    entered_by nvarchar(50) NULL
+)
+

--- a/src/grate.sqlite/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
+++ b/src/grate.sqlite/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE {{SchemaName}}_{{VersionTable}}(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repository_path nvarchar(255) NULL,
+    version nvarchar(50) NULL,
+    entry_date datetime NULL,
+    modified_date datetime NULL,
+    entered_by nvarchar(50) NULL,
+    status nvarchar(50) NULL
+)

--- a/src/grate.sqlite/grate.sqlite.csproj
+++ b/src/grate.sqlite/grate.sqlite.csproj
@@ -17,4 +17,9 @@
     <None Include="NuGet.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Bootstrapping\Sql\**\*.sql" />
+    <None Remove="Bootstrapping\Sql\**\.sql**" />
+  </ItemGroup>
+
 </Project>

--- a/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/01_create_schema_grate.ENV.GrateInternalBoostrap-a61456d0-e00a-4933-b692-c6a5d7d51539.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/01_create_schema_grate.ENV.GrateInternalBoostrap-a61456d0-e00a-4933-b692-c6a5d7d51539.sql
@@ -1,0 +1,8 @@
+-- We need to do 'if not exists' on this, as it is run twice, one for the Grate... tables,
+-- and one for the "standard" migration tables
+IF NOT EXISTS (SELECT *
+ FROM sys.schemas
+ WHERE name = N'{{SchemaName}}')
+BEGIN
+ EXEC('CREATE SCHEMA {{SchemaName}}')
+END

--- a/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE {{SchemaName}}.{{ScriptsRunTable}}(
+    id bigint IDENTITY(1,1) NOT NULL,
+    version_id BIGINT NULL,
+    script_name nvarchar(255) NULL,
+    text_of_script text NULL,
+    text_hash nvarchar(512) NULL,
+    one_time_script bit NULL,
+    entry_date datetime NULL,
+    modified_date datetime NULL,
+    entered_by nvarchar(50) NULL,
+    CONSTRAINT PK_{{ScriptsRunTable}}_id PRIMARY KEY CLUSTERED (id)
+)

--- a/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE {{SchemaName}}.{{ScriptsRunErrorsTable}}(
+    id bigint IDENTITY(1,1) NOT NULL,
+    repository_path nvarchar(255) NULL,
+    version nvarchar(50) NULL,
+    script_name nvarchar(255) NULL,
+    text_of_script text NULL,
+    erroneous_part_of_script text NULL,
+    error_message text NULL,
+    entry_date datetime NULL,
+    modified_date datetime NULL,
+    entered_by nvarchar(50) NULL,
+    CONSTRAINT PK_{{ScriptsRunErrorsTable}}_id PRIMARY KEY CLUSTERED (id)
+)
+

--- a/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/04_create_version_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE {{SchemaName}}.{{VersionTable}}(
+    id bigint IDENTITY(1,1) NOT NULL,
+    repository_path nvarchar(255) NULL,
+    version nvarchar(50) NULL,
+    entry_date datetime NULL,
+    modified_date datetime NULL,
+    entered_by nvarchar(50) NULL,
+    status nvarchar(50) NULL,
+    CONSTRAINT PK_{{VersionTable}}_id PRIMARY KEY CLUSTERED (id)
+)

--- a/src/grate.sqlserver/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,0 +1,7 @@
+IF NOT EXISTS(
+   SELECT 1 FROM sys.columns WHERE name = 'status'
+   AND OBJECT_NAME(object_id) = '{{VersionTable}}')
+BEGIN
+    ALTER TABLE {{SchemaName}}.{{VersionTable}}
+    ADD status nvarchar(50) NULL
+END

--- a/src/grate.sqlserver/grate.sqlserver.csproj
+++ b/src/grate.sqlserver/grate.sqlserver.csproj
@@ -17,4 +17,9 @@
     <None Include="NuGet.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Bootstrapping\Sql\**\*.sql" />
+    <None Remove="Bootstrapping\Sql\**\.sql**" />
+  </ItemGroup>
+
 </Project>

--- a/unittests/Basic_tests/Infrastructure/FolderConfiguration/KnownFolders_CustomNames.cs
+++ b/unittests/Basic_tests/Infrastructure/FolderConfiguration/KnownFolders_CustomNames.cs
@@ -13,7 +13,7 @@ namespace Basic_tests.Infrastructure.FolderConfiguration;
 // ReSharper disable once InconsistentNaming
 public class KnownFolders_CustomNames
 {
-    private static readonly Random Random = new();
+    private static readonly Random Random = Random.Shared;
 
     [Fact]
     public void Returns_folders_in_same_order_as_default()

--- a/unittests/Basic_tests/Infrastructure/MockDbMigrator.cs
+++ b/unittests/Basic_tests/Infrastructure/MockDbMigrator.cs
@@ -6,17 +6,11 @@ using NSubstitute;
 
 namespace Basic_tests.Infrastructure;
 
-public class MockDbMigrator: IDbMigrator
+public record MockDbMigrator: IDbMigrator
 {
-    public ValueTask DisposeAsync()
-    {
-        throw new NotImplementedException();
-    }
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    public object Clone()
-    {
-        throw new NotImplementedException();
-    }
+    object ICloneable.Clone() => this with { };
 
     public GrateConfiguration Configuration { get; set; } = null!;
     public IDatabase Database { get; set; } = Substitute.For<IDatabase>();

--- a/unittests/MariaDB/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/MariaDB/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using MariaDB.TestInfrastructure;
+
+namespace MariaDB.Bootstrapping;
+
+[Collection(nameof(MariaDbGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_internal_structure_does_not_exist(MariaDbGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_internal_structure_does_not_exist(context, testOutput);
+

--- a/unittests/MariaDB/Bootstrapping/When_Grate_structure_does_not_exist.cs
+++ b/unittests/MariaDB/Bootstrapping/When_Grate_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using MariaDB.TestInfrastructure;
+
+namespace MariaDB.Bootstrapping;
+
+[Collection(nameof(MariaDbGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_does_not_exist(MariaDbGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_does_not_exist(context, testOutput);
+

--- a/unittests/MariaDB/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/MariaDB/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,10 @@
+﻿using MariaDB.TestInfrastructure;
+
+namespace MariaDB.Bootstrapping;
+
+[Collection(nameof(MariaDbGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_is_not_latest_version(MariaDbGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput);
+

--- a/unittests/Oracle/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/Oracle/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using Oracle.TestInfrastructure;
+
+namespace Oracle.Bootstrapping;
+
+[Collection(nameof(OracleGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_internal_structure_does_not_exist(OracleGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_internal_structure_does_not_exist(context, testOutput);
+

--- a/unittests/Oracle/Bootstrapping/When_Grate_structure_does_not_exist.cs
+++ b/unittests/Oracle/Bootstrapping/When_Grate_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using Oracle.TestInfrastructure;
+
+namespace Oracle.Bootstrapping;
+
+[Collection(nameof(OracleGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_does_not_exist(OracleGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_does_not_exist(context, testOutput);
+

--- a/unittests/Oracle/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/Oracle/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,10 @@
+﻿using Oracle.TestInfrastructure;
+
+namespace Oracle.Bootstrapping;
+
+[Collection(nameof(OracleGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_is_not_latest_version(OracleGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput);
+

--- a/unittests/PostgreSQL/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/PostgreSQL/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,12 @@
+﻿using PostgreSQL.TestInfrastructure;
+
+namespace PostgreSQL.Bootstrapping;
+
+[Collection(nameof(PostgreSqlGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_internal_structure_does_not_exist(
+    PostgreSqlGrateTestContext context,
+    ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.When_Grate_internal_structure_does_not_exist(context, testOutput);
+

--- a/unittests/PostgreSQL/Bootstrapping/When_Grate_structure_already_exists.cs
+++ b/unittests/PostgreSQL/Bootstrapping/When_Grate_structure_already_exists.cs
@@ -1,0 +1,12 @@
+﻿using PostgreSQL.TestInfrastructure;
+
+namespace PostgreSQL.Bootstrapping;
+
+[Collection(nameof(PostgreSqlGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_already_exists(
+    PostgreSqlGrateTestContext context,
+    ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_already_exists(context, testOutput);
+

--- a/unittests/PostgreSQL/Bootstrapping/When_Grate_structure_does_not_exist.cs
+++ b/unittests/PostgreSQL/Bootstrapping/When_Grate_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using PostgreSQL.TestInfrastructure;
+
+namespace PostgreSQL.Bootstrapping;
+
+[Collection(nameof(PostgreSqlGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_does_not_exist(PostgreSqlGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_does_not_exist(context, testOutput);
+

--- a/unittests/PostgreSQL/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/PostgreSQL/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,10 @@
+﻿using PostgreSQL.TestInfrastructure;
+
+namespace PostgreSQL.Bootstrapping;
+
+[Collection(nameof(PostgreSqlGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_is_not_latest_version(PostgreSqlGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput);
+

--- a/unittests/SqlServer/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/SqlServer/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using SqlServer.TestInfrastructure;
+
+namespace SqlServer.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_internal_structure_does_not_exist(SqlServerGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_internal_structure_does_not_exist(context, testOutput);
+

--- a/unittests/SqlServer/Bootstrapping/When_Grate_structure_does_not_exist.cs
+++ b/unittests/SqlServer/Bootstrapping/When_Grate_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using SqlServer.TestInfrastructure;
+
+namespace SqlServer.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_does_not_exist(SqlServerGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_does_not_exist(context, testOutput);
+

--- a/unittests/SqlServer/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/SqlServer/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,10 @@
+﻿using SqlServer.TestInfrastructure;
+
+namespace SqlServer.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_is_not_latest_version(SqlServerGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput);
+

--- a/unittests/SqlServerCaseSensitive/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/SqlServerCaseSensitive/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using SqlServerCaseSensitive.TestInfrastructure;
+
+namespace SqlServerCaseSensitive.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_internal_structure_does_not_exist(SqlServerGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_internal_structure_does_not_exist(context, testOutput);
+

--- a/unittests/SqlServerCaseSensitive/Bootstrapping/When_Grate_structure_does_not_exist.cs
+++ b/unittests/SqlServerCaseSensitive/Bootstrapping/When_Grate_structure_does_not_exist.cs
@@ -1,0 +1,10 @@
+﻿using SqlServerCaseSensitive.TestInfrastructure;
+
+namespace SqlServerCaseSensitive.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_does_not_exist(SqlServerGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_does_not_exist(context, testOutput);
+

--- a/unittests/SqlServerCaseSensitive/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/SqlServerCaseSensitive/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,10 @@
+﻿using SqlServerCaseSensitive.TestInfrastructure;
+
+namespace SqlServerCaseSensitive.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_is_not_latest_version(SqlServerGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput);
+

--- a/unittests/Sqlite/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/Sqlite/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,11 @@
+﻿using Sqlite.TestInfrastructure;
+using TestCommon.TestInfrastructure;
+
+namespace Sqlite.Bootstrapping;
+
+[Collection(nameof(SqliteTestDatabase))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_internal_structure_does_not_exist(SqliteGrateTestContext context, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.When_Grate_internal_structure_does_not_exist(context, testOutput);
+

--- a/unittests/Sqlite/Bootstrapping/When_Grate_structure_already_exists.cs
+++ b/unittests/Sqlite/Bootstrapping/When_Grate_structure_already_exists.cs
@@ -1,0 +1,11 @@
+﻿using Sqlite.TestInfrastructure;
+using TestCommon.TestInfrastructure;
+
+namespace Sqlite.Bootstrapping;
+
+[Collection(nameof(SqliteTestDatabase))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_already_exists(SqliteGrateTestContext context, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_already_exists(context, testOutput);
+

--- a/unittests/Sqlite/Bootstrapping/When_Grate_structure_does_not_exist.cs
+++ b/unittests/Sqlite/Bootstrapping/When_Grate_structure_does_not_exist.cs
@@ -1,0 +1,11 @@
+﻿using Sqlite.TestInfrastructure;
+using TestCommon.TestInfrastructure;
+
+namespace Sqlite.Bootstrapping;
+
+[Collection(nameof(SqliteTestDatabase))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_does_not_exist(SqliteGrateTestContext context, ITestOutputHelper testOutput) 
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_does_not_exist(context, testOutput);
+

--- a/unittests/Sqlite/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/Sqlite/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,15 @@
+﻿using Sqlite.TestInfrastructure;
+using TestCommon.TestInfrastructure;
+
+namespace Sqlite.Bootstrapping;
+
+[Collection(nameof(SqliteTestDatabase))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class When_Grate_structure_is_not_latest_version(SqliteGrateTestContext context, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput)
+{
+    [Fact(Skip = "Not able to apply logic to DDL statements for Sqlite")]
+    public override Task The_latest_version_is_applied() => Task.CompletedTask;
+}
+

--- a/unittests/Sqlite/TestInfrastructure/SqliteGrateTestContext.cs
+++ b/unittests/Sqlite/TestInfrastructure/SqliteGrateTestContext.cs
@@ -13,39 +13,32 @@ namespace Sqlite.TestInfrastructure;
 [CollectionDefinition(nameof(SqliteGrateTestContext))]
 public class SqliteTestCollection : ICollectionFixture<SqliteGrateTestContext>;
 
-public class SqliteGrateTestContext : IGrateTestContext
+public class SqliteGrateTestContext : GrateTestContext
 {
     public SqliteGrateTestContext(
-        IGrateMigrator migrator, 
-        ITestDatabase _)
+        IGrateMigrator migrator,
+        ITestDatabase testDatabase) : base(testDatabase)
     {
         Migrator = migrator;
     }
+    
+    public override IDbConnection GetDbConnection(string connectionString) => new SqliteConnection(connectionString);
 
-    public string AdminConnectionString => $"Data Source=grate-sqlite.db";
-    public string ConnectionString(string database) => $"Data Source={database}.db";
-    public string UserConnectionString(string database) => $"Data Source={database}.db";
+    public override ISyntax Syntax => new SqliteSyntax();
+    public override Type DbExceptionType => typeof(SqliteException);
 
-    public IDbConnection GetDbConnection(string connectionString) => new SqliteConnection(connectionString);
+    public override Type DatabaseType => typeof(SqliteDatabase);
+    public override bool SupportsTransaction => false;
 
-    public ISyntax Syntax => new SqliteSyntax();
-    public Type DbExceptionType => typeof(SqliteException);
-
-    public Type DatabaseType => typeof(SqliteDatabase);
-    public bool SupportsTransaction => false;
-    // public string DatabaseTypeName => "Sqlite";
-    // public string MasterDatabase => "master";
-
-
-    public SqlStatements Sql => new()
+    public override SqlStatements Sql => new()
     {
         SelectVersion = "SELECT sqlite_version();",
     };
 
 
-    public string ExpectedVersionPrefix => throw new NotSupportedException("Sqlite does not support versioning");
-    public bool SupportsCreateDatabase => false;
-    public bool SupportsSchemas => false;
+    public override string ExpectedVersionPrefix => throw new NotSupportedException("Sqlite does not support versioning");
+    public override bool SupportsCreateDatabase => false;
+    public override bool SupportsSchemas => false;
 
-    public IGrateMigrator Migrator { get; }
+    public override IGrateMigrator Migrator { get; }
 }

--- a/unittests/Sqlite/TestInfrastructure/SqliteTestDatabase.cs
+++ b/unittests/Sqlite/TestInfrastructure/SqliteTestDatabase.cs
@@ -3,7 +3,8 @@
 using Microsoft.Data.Sqlite;
 using Xunit.Sdk;
 namespace TestCommon.TestInfrastructure;
-public class SqliteTestDatabase(IMessageSink messageSink) : ITestDatabase
+
+public class SqliteTestDatabase(IMessageSink messageSink) : ITestDatabase, IAsyncLifetime
 {
     public Task DisposeAsync()
     {

--- a/unittests/TestCommon/Generic/Bootstrapping/When_Grate_Structure_Doesnt_Exist.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/When_Grate_Structure_Doesnt_Exist.cs
@@ -1,0 +1,139 @@
+﻿using Dapper;
+using FluentAssertions;
+using grate.Configuration;
+using grate.Infrastructure;
+using grate.Migration;
+using TestCommon.Generic.Running_MigrationScripts;
+using TestCommon.TestInfrastructure;
+using Xunit.Abstractions;
+using static grate.Configuration.KnownFolderKeys;
+
+namespace TestCommon.Generic.Bootstrapping;
+
+public abstract class When_Grate_structure_does_not_exist(IGrateTestContext context, ITestOutputHelper testOutput) 
+: MigrationsScriptsBase(context, testOutput)
+{
+    [Fact]
+    public async Task Schema_is_created()
+    {
+        if (!Context.SupportsSchemas)
+        {
+            return;
+        }
+        
+        var db = TestConfig.RandomDatabase();
+        var schemaName = Random.Shared.GetString(15);
+        var parent = CreateRandomTempDirectory();
+        
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithSchema(schemaName)
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+
+        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        {
+            await RunMigration(migrator);
+        }
+
+        string? schema;
+        string sql =
+            $"SELECT s.SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA s WHERE s.SCHEMA_NAME = '{schemaName}'";
+
+        using (var conn = Context.CreateDbConnection(db))
+        {
+            schema = await conn.ExecuteScalarAsync<string>(sql);
+        }
+
+        schema.Should().Be(schemaName);
+    }
+
+    [Fact]
+    public async Task ScriptsRun_Table_Is_Created()
+    {
+        var db = TestConfig.RandomDatabase();
+        var schemaName = Random.Shared.GetString(15);
+        var scriptsRunTableName = Random.Shared.GetString(15);
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithSchema(schemaName)
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build()
+            with {ScriptsRunTableName = scriptsRunTableName};
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+
+        var scriptsRunTable= await migrator.GetDbMigrator().Database.ExistingTable(schemaName, scriptsRunTableName);
+        scriptsRunTable.Should().NotBeNull();
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        scriptsRunTable!.ToUpper().Should().Be(scriptsRunTable.ToUpper());
+    }
+    
+    [Fact]
+    public async Task ScriptsRunError_Table_Is_Created()
+    {
+        var db = TestConfig.RandomDatabase();
+        var schemaName = Random.Shared.GetString(15);
+        var scriptsErrorTableName = Random.Shared.GetString(15);
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+                .WithConnectionString(Context.ConnectionString(db))
+                .WithSchema(schemaName)
+                .WithFolders(FoldersConfiguration.Default())
+                .WithSqlFilesDirectory(parent)
+                .Build()
+            with {ScriptsRunErrorsTableName = scriptsErrorTableName};
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+        
+        var scriptsErrorTable = await migrator.GetDbMigrator().Database.ExistingTable(schemaName, scriptsErrorTableName);
+        scriptsErrorTable.Should().NotBeNull();
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        scriptsErrorTable!.ToUpper().Should().Be(scriptsErrorTableName.ToUpper());
+    }
+    
+     
+    [Fact]
+    public async Task Version_Table_Is_Created()
+    {
+        var db = TestConfig.RandomDatabase();
+        var schemaName = Random.Shared.GetString(15);
+        var versionTableName = Random.Shared.GetString(15);
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+                .WithConnectionString(Context.ConnectionString(db))
+                .WithSchema(schemaName)
+                .WithFolders(FoldersConfiguration.Default())
+                .WithSqlFilesDirectory(parent)
+                .Build()
+            with {VersionTableName = versionTableName};
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+
+        var versionTable = await migrator.GetDbMigrator().Database.ExistingTable(schemaName, versionTableName);
+        versionTable.Should().NotBeNull();
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        versionTable!.ToUpper().Should().Be(versionTable.ToUpper());
+    }
+    
+    
+    private async Task RunMigration(IGrateMigrator migrator)
+    {
+        var config = migrator.Configuration;
+        CreateDummySql(config.SqlFilesDirectory, config.Folders![Sprocs]);
+        await migrator.Migrate();
+    }
+
+}

--- a/unittests/TestCommon/Generic/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/When_Grate_internal_structure_does_not_exist.cs
@@ -1,0 +1,126 @@
+﻿using Dapper;
+using FluentAssertions;
+using grate.Configuration;
+using grate.Migration;
+using TestCommon.Generic.Running_MigrationScripts;
+using TestCommon.TestInfrastructure;
+using Xunit.Abstractions;
+using static grate.Configuration.KnownFolderKeys;
+
+namespace TestCommon.Generic.Bootstrapping;
+
+public abstract class When_Grate_internal_structure_does_not_exist(IGrateTestContext context, ITestOutputHelper testOutput) 
+: MigrationsScriptsBase(context, testOutput)
+{
+    [Fact]
+    public async Task GrateScriptsRun_Table_Is_Created()
+    {
+        var db = TestConfig.RandomDatabase();
+        var grateScriptsRunTableName = "GrateScriptsRun";
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+
+        var grateScriptsRunTable = await migrator.GetDbMigrator().Database.ExistingTable(config.SchemaName, grateScriptsRunTableName);
+        grateScriptsRunTable.Should().NotBeNull();
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        grateScriptsRunTable!.ToUpper().Should().Be(grateScriptsRunTable.ToUpper());
+    }
+    
+    [Fact]
+    public async Task ScriptsRunError_Table_Is_Created()
+    {
+        var db = TestConfig.RandomDatabase();
+        var grateScriptsErrorTableName = "GrateScriptsRunErrors";
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+        
+        var scriptsErrorTable = await migrator.GetDbMigrator().Database.ExistingTable(config.SchemaName, grateScriptsErrorTableName);
+        scriptsErrorTable.Should().NotBeNull();
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        scriptsErrorTable!.ToUpper().Should().Be(scriptsErrorTable.ToUpper());
+    }
+    
+     
+    [Fact]
+    public async Task Version_Table_Is_Created()
+    {
+        var db = TestConfig.RandomDatabase();
+        var grateVersionTableName = "GrateVersion";
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+
+        var grateVersionTable = await migrator.GetDbMigrator().Database.ExistingTable(config.SchemaName, grateVersionTableName);
+        grateVersionTable.Should().NotBeNull();
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        grateVersionTable!.ToUpper().Should().Be(grateVersionTable.ToUpper());
+    }
+    
+    [Theory]
+    [InlineData("02_create_scripts_run_table.sql")]
+    [InlineData("03_create_scripts_run_errors_table.sql")]
+    [InlineData("04_create_version_table.sql")]
+    public async Task Logs_internal_scripts_run_in_own_structure(string name)
+    {
+        var db = TestConfig.RandomDatabase();
+        var grateScriptsRunTableName = "GrateScriptsRun";
+        var parent = CreateRandomTempDirectory();
+
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+
+        await using var migrator = Context.Migrator.WithConfiguration(config);
+        await RunMigration(migrator);
+
+        string[] scriptNames;
+        string sql = $"SELECT script_name FROM {Context.Syntax.TableWithSchema("grate", grateScriptsRunTableName)}";
+
+        using (var conn = Context.CreateDbConnection(db))
+        {
+            scriptNames = (await conn.QueryAsync<string>(sql)).ToArray();
+        }
+
+        // The scripts should have been logged twice, once for the creation of the "meta" tables, with the prefix "bootstrap/"
+        // (GrateScriptsRun, GrateScriptsRunErrors and GrateVersion), and once for the creation of the actual table
+        // (ScriptsRun, ScriptsRunErrors and Version)
+        scriptNames.Should().Contain(name);
+        scriptNames.Should().Contain($"grate-internal/{name}");
+    }
+
+    private async Task RunMigration(IGrateMigrator migrator)
+    {
+        var config = migrator.Configuration;
+        CreateDummySql(config.SqlFilesDirectory, config.Folders![Sprocs]);
+        await migrator.Migrate();
+    }
+
+}

--- a/unittests/TestCommon/Generic/Bootstrapping/When_Grate_structure_already_exists.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/When_Grate_structure_already_exists.cs
@@ -1,0 +1,120 @@
+﻿using System.Data;
+using System.Text.RegularExpressions;
+using Dapper;
+using FluentAssertions;
+using grate.Configuration;
+using grate.Infrastructure;
+using grate.Migration;
+using TestCommon.Generic.Running_MigrationScripts;
+using TestCommon.TestInfrastructure;
+using Xunit.Abstractions;
+
+namespace TestCommon.Generic.Bootstrapping;
+
+// ReSharper disable once UnusedType.Global
+public abstract class When_Grate_structure_already_exists(IGrateTestContext context, ITestOutputHelper testOutput)
+    : MigrationsScriptsBase(context, testOutput)
+{
+
+    [Fact]
+    public async Task The_initial_structure_is_created_as_a_baseline()
+    {
+        var db = TestConfig.RandomDatabase();
+        var parent = CreateRandomTempDirectory();
+        
+        // This will create the grate tables beforehand, without registering it
+           
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+        
+        // Create database
+        using (var adminConn = Context.CreateAdminDbConnection())
+        {
+            await adminConn.ExecuteAsync(Context.Syntax.CreateDatabase(db, null));
+        }
+        
+        var conn = Context.CreateDbConnection(db);
+
+        var resources = TestInfrastructure.Bootstrapping.GetBootstrapScripts(this.Context.DatabaseType, "Baseline");
+        
+        foreach (var resource in resources)
+        {
+            var resourceText = await TestInfrastructure.Bootstrapping.GetContent(this.Context.DatabaseType.Assembly, resource);
+          
+            resourceText = resourceText.Replace("{{ScriptsRunTable}}", "ScriptsRun");
+            resourceText = resourceText.Replace("{{ScriptsRunErrorsTable}}", "ScriptsRunErrorsTable");
+            resourceText = resourceText.Replace("{{VersionTable}}", "Version");
+            resourceText = resourceText.Replace("{{SchemaName}}", config.SchemaName);
+            
+            await conn.ExecuteAsync(resourceText);
+        }
+
+        conn.Close();
+        
+        // Check that the tables have been created
+        var tableWithSchema = Context.Syntax.TableWithSchema(config.SchemaName, config.VersionTableName);
+        var selectSql = $"SELECT * FROM {tableWithSchema}";
+        
+        conn = Context.CreateDbConnection(db);
+        var reader = await conn.ExecuteReaderAsync(selectSql);
+        
+        var columns = GetColumns(reader).Select(column => column.ToUpper());
+        TryClose(conn);
+        columns.Should().NotBeEmpty();
+        
+        // Run the migration
+        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        {
+            await RunMigration(migrator);
+        }
+        
+        // Check that the scripts have been registered as a baseline:
+        
+        // We should have at least 6 rows in the ScriptsRun table, as there are 3 or 4 scripts in the baseline,
+        // depending on whether the database supports schemas or not
+        var grateInternalScriptsRunTable = Context.Syntax.TableWithSchema(config.SchemaName, "GrateScriptsRun");
+        selectSql = $"SELECT COUNT(*) FROM {grateInternalScriptsRunTable}";
+        conn = Context.CreateDbConnection(db);
+        var count = await conn.QueryFirstOrDefaultAsync<int>(selectSql);
+        count.Should().BeGreaterOrEqualTo(6);
+        
+        TryClose(conn);
+    }
+
+
+
+    private async Task RunMigration(IGrateMigrator migrator)
+    {
+        var config = migrator.Configuration;
+        CreateDummySql(config.SqlFilesDirectory, config.Folders![KnownFolderKeys.Up]);
+        await migrator.Migrate();
+    }
+
+    private static List<string> GetColumns(IDataReader reader)
+    {
+        var columns = Enumerable.Range(0, reader.FieldCount)
+            .Select(reader.GetName)
+            .ToList();
+        return columns;
+    }
+    
+    private static void TryClose(IDbConnection conn)
+    {
+        try
+        {
+            if (conn.State == ConnectionState.Open)
+            {
+                conn.Close();
+            }
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
+    }
+    
+}
+

--- a/unittests/TestCommon/Generic/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,0 +1,134 @@
+﻿using System.Data;
+using System.Text.RegularExpressions;
+using Dapper;
+using FluentAssertions;
+using grate.Configuration;
+using grate.Migration;
+using TestCommon.Generic.Running_MigrationScripts;
+using TestCommon.TestInfrastructure;
+using Xunit.Abstractions;
+using static System.StringSplitOptions;
+
+namespace TestCommon.Generic.Bootstrapping;
+
+// ReSharper disable once UnusedType.Global
+public abstract class When_Grate_structure_is_not_latest_version(IGrateTestContext context, ITestOutputHelper testOutput)
+    : MigrationsScriptsBase(context, testOutput)
+{
+
+    [Fact]
+    public virtual async Task The_latest_version_is_applied()
+    {
+        var db = TestConfig.RandomDatabase();
+        var parent = CreateRandomTempDirectory();
+        
+        // This will create the version table without the status column
+           
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+        
+        // Create database
+        var password = Context.AdminConnectionString
+            .Split(";", TrimEntries | RemoveEmptyEntries)
+            .SingleOrDefault(entry => entry.StartsWith("Password") || entry.StartsWith("Pwd"))?
+            .Split("=", TrimEntries | RemoveEmptyEntries)
+            .Last();
+
+        var createDatabaseSql = Context.Syntax.CreateDatabase(db, password);
+        using (var adminConn = Context.CreateAdminDbConnection())
+        {
+            await adminConn.ExecuteAsync(createDatabaseSql);
+        }
+        
+        var conn = Context.CreateDbConnection(db);
+
+        var resources = TestInfrastructure.Bootstrapping.GetBootstrapScripts(this.Context.DatabaseType, "Baseline");
+        
+        foreach (var resource in resources)
+        {
+            var resourceText = await TestInfrastructure.Bootstrapping.GetContent(this.Context.DatabaseType.Assembly, resource);
+            if (resource.Contains("04_create_version_table"))
+            {
+                resourceText = Regex.Replace(
+                    resourceText,
+                    @"^(\s*entered_by[^,\n]*),?\s*status[^,\n]*(,?\n)", "$1$2",
+                    RegexOptions.Multiline
+                    );
+            }
+            
+            resourceText = resourceText.Replace("{{ScriptsRunTable}}", "ScriptsRun");
+            resourceText = resourceText.Replace("{{ScriptsRunErrorsTable}}", "ScriptsRunErrorsTable");
+            resourceText = resourceText.Replace("{{VersionTable}}", "Version");
+            resourceText = resourceText.Replace("{{SchemaName}}", config.SchemaName);
+            
+            await conn.ExecuteAsync(resourceText);
+        }
+
+        conn.Close();
+     
+        
+        // Check that the status column is not there
+        var tableWithSchema = Context.Syntax.TableWithSchema(config.SchemaName, config.VersionTableName);
+        var selectSql = $"SELECT * FROM {tableWithSchema}";
+        
+        conn = Context.CreateDbConnection(db);
+        var reader = await conn.ExecuteReaderAsync(selectSql);
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        var columns = GetColumns(reader).Select(column => column.ToUpper());
+        TryClose(conn);
+        columns.Should().NotContain("status".ToUpper());
+        
+        // Run the migration
+        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        {
+            await RunMigration(migrator);
+        }
+        
+        // Check that the status column has been added
+        conn = Context.CreateDbConnection(db);
+        reader = await conn.ExecuteReaderAsync(selectSql);
+        
+        // Not all databases are case-sensitive, so we can't guarantee the case of the table name
+        columns = GetColumns(reader).Select(column => column.ToUpper());
+        TryClose(conn);
+        columns.Should().Contain("status".ToUpper());
+    }
+
+
+
+    private async Task RunMigration(IGrateMigrator migrator)
+    {
+        var config = migrator.Configuration;
+        CreateDummySql(config.SqlFilesDirectory, config.Folders![KnownFolderKeys.Up]);
+        await migrator.Migrate();
+    }
+
+    private static List<string> GetColumns(IDataReader reader)
+    {
+        var columns = Enumerable.Range(0, reader.FieldCount)
+            .Select(reader.GetName)
+            .ToList();
+        return columns;
+    }
+    
+    private static void TryClose(IDbConnection conn)
+    {
+        try
+        {
+            if (conn.State == ConnectionState.Open)
+            {
+                conn.Close();
+            }
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
+    }
+    
+}
+

--- a/unittests/TestCommon/TestInfrastructure/Bootstrapping.cs
+++ b/unittests/TestCommon/TestInfrastructure/Bootstrapping.cs
@@ -1,0 +1,78 @@
+﻿using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace TestCommon.TestInfrastructure;
+
+internal static class Bootstrapping
+{
+    internal static IEnumerable<string> GetBootstrapScripts(
+        Type databasetype,
+        string resourcePrefix
+    )
+    {
+        var assembly = databasetype.Assembly;
+
+        // If the resource prefix starts with a number, we need to prefix it with an underscore
+        if (Regex.IsMatch(resourcePrefix, "^\\d"))
+        {
+            resourcePrefix = $"_{resourcePrefix}";
+        }
+
+        var prefix = $"{assembly.GetName().Name}.Bootstrapping.Sql.{resourcePrefix}";
+
+        var resources = assembly.GetManifestResourceNames()
+            .Where(x => x.StartsWith(prefix))
+            .ToArray();
+
+        return resources;
+    }
+
+
+    internal static async Task<string> GetContent(
+        Assembly assembly,
+        string resource)
+    {
+        var resourceStream = assembly.GetManifestResourceStream(resource);
+        if (resourceStream is null)
+        {
+            throw new Exception($"Resource {resource} not found");
+        }
+
+        using var streamReader = new StreamReader(resourceStream);
+        var resourceText = await streamReader.ReadToEndAsync();
+
+        return resourceText;
+    }
+    
+    internal static async Task WriteResourceToFolder(
+        string resource,
+        string resourceText,
+        string folder,
+        string resourcePrefix,
+        string? sqlFolderNamePrefix)
+    {
+        var prefix = $".Bootstrapping.Sql.{resourcePrefix}";
+        var index = resource.IndexOf(prefix, StringComparison.Ordinal) + prefix.Length;
+
+        var prefixLength = index;
+
+        var nextDot = resource.IndexOf('.', prefixLength + 1);
+        var folderName = resource.Substring(prefixLength + 1, nextDot - prefixLength - 1);
+            
+        var fullFolder = sqlFolderNamePrefix is {} 
+            ? Path.Combine(folder, folderName, sqlFolderNamePrefix)
+            : Path.Combine(folder, folderName);
+        
+        if (!Directory.Exists(fullFolder))
+        {
+            Directory.CreateDirectory(fullFolder);
+        }
+            
+        var resourceName = resource.Substring(prefixLength + 1 + folderName.Length + 1);
+
+        var filePath = Path.Combine(fullFolder, resourceName);
+        await File.WriteAllTextAsync(filePath, resourceText);
+    }
+    
+    
+}

--- a/unittests/TestCommon/TestInfrastructure/TestConfig.cs
+++ b/unittests/TestCommon/TestInfrastructure/TestConfig.cs
@@ -6,7 +6,7 @@ namespace TestCommon.TestInfrastructure;
 
 public static class TestConfig
 {
-    private static readonly Random Random = new();
+    private static readonly Random Random = Random.Shared;
 
     public static string RandomDatabase() => Random.GetString(15);
 


### PR DESCRIPTION
 Dog-fooding: Use grate to version grate tables
    
  Use grate itself to version the grate tables, instead of doing this explicitly in code.
  This is good for two reasons:
  1) We use the best tool out there to version the database ;)
  2) It makes (overdue) changes to some of the grate tables (using outdated types, etc) easier
  
  I introduced a set of "meta" grate tables to handle the versioning of the Grate tables themselves.
  So, in addition to (default names):
  
  * ScriptsRun
  * ScriptsRunErrors
  * Version
  
  we add these tables, to version the tables above:
  
  * GrateScriptsRun
  * GrateScriptsRunErrors
  * GrateVersion
  
  for versioning these tables themselves, we put the versioning _in_ the same tables
  (using delayed writing to the tables for bootstrapping)
  
  * Wrote tests for existing functionality to make sure we don't break anything
  * Made sure internal tables are created
  * Fixed case-sensitivity in tests
  * Smink -> 0.3.0 (test reporting)
