### PR TITLE
Issue #492: Add support for multiple simultaneous environments

### DIFF
--- a/src/grate.core/Configuration/GrateConfiguration.cs
+++ b/src/grate.core/Configuration/GrateConfiguration.cs
@@ -73,10 +73,20 @@ public record GrateConfiguration
     /// </summary>
     public bool Transaction { get; init; }
 
+    // /// <summary>
+    // /// The environment the current migration is targeting for env-specific scripts.
+    // /// </summary>
+    // public string? Environments { get; init; }
+
     /// <summary>
     /// The environment the current migration is targeting for env-specific scripts.
     /// </summary>
-    public GrateEnvironment? Environment { get; init; }
+    public GrateEnvironment? Environment { get; set; }
+    // {
+    //     get => Environments is {} ? new(Environments) : null;
+    //     init => Environments = string.Join(",", value?.Environments ?? []);
+    // }
+
 
     /// <summary>
     /// The optional repository path value used to track along with version.

--- a/src/grate.core/Infrastructure/GrateEnvironment.cs
+++ b/src/grate.core/Infrastructure/GrateEnvironment.cs
@@ -2,20 +2,40 @@
 
 namespace grate.Infrastructure;
 
-public record GrateEnvironment(string Current)
+public record GrateEnvironment
 {
+    public GrateEnvironment(string environment)
+    {
+        _environments = new[] { environment };
+    }
+    
+    public GrateEnvironment(params string[] environments)
+    {
+        _environments = environments;
+    }
+    
+    public GrateEnvironment(IEnumerable<string> environments)
+    {
+        _environments = environments;
+    }
+
     /// <summary>
     /// The name of the Environment
     /// </summary>
-    public string Current { get; } = Current;
+    public string Current => _environments.FirstOrDefault() ?? string.Empty;
+
+    private readonly IEnumerable<string> _environments;
+
+    public IEnumerable<string> Environments => _environments;
 
     private const string EnvironmentMarker = ".ENV.";
 
     public bool ShouldRun(string path) => !IsEnvironmentFile(path) || IsForCurrentEnvironment(path);
 
     private bool IsForCurrentEnvironment(string path) =>
-        FileName(path).StartsWith($"{Current}.", InvariantCultureIgnoreCase) ||
-        FileName(path).Contains($".{Current}.", InvariantCultureIgnoreCase);
+        _environments.Any(env =>
+            FileName(path).StartsWith($"{env}.", InvariantCultureIgnoreCase) ||
+            FileName(path).Contains($".{env}.", InvariantCultureIgnoreCase));
 
     public static bool IsEnvironmentFile(string fileName) => fileName.Contains(EnvironmentMarker, InvariantCultureIgnoreCase);
     private static string FileName(string path) => new FileInfo(path).Name;
@@ -26,4 +46,9 @@ public record GrateEnvironment(string Current)
     // environment that an actual user might use (which would make things crash badly)
     public static GrateEnvironment Internal { get; } = new("GrateInternal-a01ce6e6-0038-4ebe-959e-7d039f6435bf");
     public static GrateEnvironment InternalBootstrap { get; } = new("GrateInternalBoostrap-a61456d0-e00a-4933-b692-c6a5d7d51539");
+
+    public void Deconstruct(out string first)
+    {
+        first = this.Current;
+    }
 }

--- a/src/grate/Commands/MigrateCommand.cs
+++ b/src/grate/Commands/MigrateCommand.cs
@@ -23,7 +23,7 @@ internal sealed class MigrateCommand : RootCommand
         Add(CommandTimeoutAdmin());
         Add(DatabaseType());
         Add(RunInTransaction());
-        Add(Environment());
+        Add(Environments());
         Add(SchemaName());
         Add(Silent());
         Add(RepositoryPath());
@@ -178,7 +178,7 @@ the last one will expect the folders to be named 'folder1', 'folder2', and 'fold
         new Option<DatabaseType>(
             new[] { "--databasetype", "--dt", "--dbt" },
             () => Configuration.DatabaseType.SQLServer,
-            "Tells grate what type of database it is running on."
+           "TELLS GRATE WHAT TYPE OF DATABASE IT IS RUNNING ON."
         );
 
     private static Option RunInTransaction() => //new Argument<bool>("-t");
@@ -207,12 +207,32 @@ the last one will expect the folders to be named 'folder1', 'folder2', and 'fold
 
 
     //ENVIRONMENT OPTIONS
-    private static Option<GrateEnvironment?> Environment() =>
+    //private static Option<CommandLineGrateEnvironment?> Environments() =>
+    private static Option<CommandLineGrateEnvironment?> Environments() =>
         new(
             aliases: new[] { "--env", "--environment" },
-            parseArgument: ArgumentParsers.ParseEnvironment, // Needed in System.CommandLine beta3: https://github.com/dotnet/command-line-api/issues/1664
-            description: "Environment Name - This allows grate to be environment aware and only run scripts that are in a particular environment based on the name of the script.  'something.ENV.LOCAL.sql' would only be run if --env=LOCAL was set."
-        );
+            parseArgument: ArgumentParsers
+                .ParseEnvironment, // Needed in System.CommandLine beta3: https://github.com/dotnet/command-line-api/issues/1664
+            description:
+            "Environment Name - This allows grate to be environment aware and only run scripts that are in a particular environment based on the name of the script.  'something.ENV.LOCAL.sql' would only be run if --env=LOCAL was set."
+        )
+        {
+            AllowMultipleArgumentsPerToken = true
+            //Arity = ArgumentArity.ZeroOrMore
+        };
+    //
+    // private static Option<string?> Environments() =>
+    //     new(
+    //         aliases: new[] { "--envs", "--environments" },
+    //         parseArgument: ArgumentParsers.ParseEnvironmentString, // Needed in System.CommandLine beta3: https://github.com/dotnet/command-line-api/issues/1664
+    //         description: "Environment Name - This allows grate to be environment aware and only run scripts that are in a particular environment based on the name of the script.  'something.ENV.LOCAL.sql' would only be run if --env=LOCAL was set."
+    //     );
+    
+    // private static Option<string> Environments() =>
+    //     new(
+    //         aliases: new[] { "--env", "--environment" },
+    //         description: "Environment Name - This allows grate to be environment aware and only run scripts that are in a particular environment based on the name of the script.  'something.ENV.LOCAL.sql' would only be run if --env=LOCAL was set."
+    //     );
 
 
     //WARNING OPTIONS

--- a/src/grate/Configuration/ArgumentParsers.cs
+++ b/src/grate/Configuration/ArgumentParsers.cs
@@ -1,22 +1,22 @@
 ﻿using System.CommandLine.Parsing;
-using grate.Infrastructure;
 
 namespace grate.Configuration;
 
 internal static class ArgumentParsers
 {
+    private static readonly char[] Delimiters = [',', ';'];
+
     // System.CommandLine beta3 has broken support for basic public constructors in order to provide better support for trimming assemblies.
     // Specify a parser to work around this, see https://github.com/dotnet/command-line-api/issues/1664
-
-    public static GrateEnvironment? ParseEnvironment(ArgumentResult result)
+    public static CommandLineGrateEnvironment? ParseEnvironment(ArgumentResult result)
     {
-        if (result.Tokens.Count == 1)
-        {
-            return new GrateEnvironment(result.Tokens[0].Value);
-        }
+        return result.Tokens.Any() 
+            ? new CommandLineGrateEnvironment(result.Tokens.SelectMany(GetEnvironments)) 
+            : null;
+    }
 
-        result.ErrorMessage = $"Arg specified multiple times.";
-
-        return default;
+    private static IEnumerable<string> GetEnvironments(Token token)
+    {
+        return token.Value.Split(Delimiters, StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/src/grate/Configuration/CommandLineGrateEnvironment.cs
+++ b/src/grate/Configuration/CommandLineGrateEnvironment.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using grate.Infrastructure;
+
+namespace grate.Configuration;
+
+internal record CommandLineGrateEnvironment: GrateEnvironment, IEnumerable<string>, IEnumerable<GrateEnvironment>
+{
+    public CommandLineGrateEnvironment(string value) : base(value)
+    {
+    }
+    
+    public CommandLineGrateEnvironment(IEnumerable<string> environments) : base(environments)
+    {
+    }
+
+    IEnumerator<GrateEnvironment> IEnumerable<GrateEnvironment>.GetEnumerator() =>
+        new GrateEnvironment[] { this }.AsEnumerable().GetEnumerator();
+
+    public IEnumerator<string> GetEnumerator() => Environments.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => Environments.GetEnumerator();
+    
+}

--- a/unittests/Basic_tests/CommandLineParsing/Basic_CommandLineParsing.cs
+++ b/unittests/Basic_tests/CommandLineParsing/Basic_CommandLineParsing.cs
@@ -177,17 +177,55 @@ public class Basic_CommandLineParsing
 
         cfg?.Transaction.Should().Be(false);
     }
+    
+    
+    /// <summary>
+    /// We can use multiple environments, separated by space, ; or ,
+    /// This makes it possible to create orhotogonal environments, and run scripts
+    /// that are specific to a combination of environments.
+    ///
+    /// Example: You have:
+    /// * Some scripts that you only run for Customer 1
+    /// * Some scripts that you only run for Customer 2
+    /// * some scripts that you only run for Azure
+    /// * some scripts that you only run for AWS
+    /// * some scripts that you only run for Dev.
+    /// * some scripts that you only run for Test.
+    /// * some scripts that you only run for Prod.
+    ///
+    /// Then, you can combine any of these environments to create a specific environment, to avoid
+    /// having to create an environment for each combination.
+    ///
+    /// E.g.:
+    /// --env Customer1;Azure
+    /// --env Customer2,Azure
+    /// --env Customer3
+    /// --env Customer1 AWS Dev
+    /// --env Customer1,AWS,Test
+    /// --env Customer2;AWS;QA
+    /// --env Customer2 AWS QA
+    /// etc
+    /// </summary>
+    /// <param name="argName"></param>
+    /// <param name="expected"></param>
 
     [Theory]
-    [InlineData("--env KASHMIR", "KASHMIR")]
-    [InlineData("--environment JALLA", "JALLA")]
-    public async Task Environment(string argName, string expected)
+    [InlineData("--env KASHMIR", new[] {"KASHMIR"})]
+    [InlineData("--env JALLA", new[] {"JALLA"})]
+    [InlineData("--env JALLA KASHMIR", new[] {"JALLA", "KASHMIR"})]
+    [InlineData("--env JALLA,BERGEN", new[] {"JALLA", "BERGEN"})]
+    [InlineData("--env Dev;Azure;OnlyOnMondays", new[] {"Dev", "Azure", "OnlyOnMondays"})]
+    [InlineData("--env Customer1;Azure;Dev", new[] {"Customer1", "Azure", "Dev"})]
+    [InlineData("--env Customer1;Azure;Test", new[] {"Customer1", "Azure", "Test"})]
+    [InlineData("--env Customer2;Azure;Dev", new[] {"Customer2", "Azure", "Dev"})]
+    [InlineData("--env Customer2;Aws;QA", new[] {"Customer2", "Aws", "QA"})]
+    [InlineData("--env Customer2;Azure;Prod", new[] {"Customer2", "Azure", "Prod"})]
+    public async Task Environments(string argName, IEnumerable<string> expected)
     {
         var commandline = argName;
         var cfg = await ParseGrateConfiguration(commandline);
 
         var expectedEnvironment = new GrateEnvironment(expected);
-
         cfg?.Environment.Should().BeEquivalentTo(expectedEnvironment);
     }
 

--- a/unittests/Basic_tests/Infrastructure/GrateEnvironment_.cs
+++ b/unittests/Basic_tests/Infrastructure/GrateEnvironment_.cs
@@ -42,6 +42,17 @@ public class GrateEnvironment_
 
         env.ShouldRun(file).Should().BeTrue();
     }
+    
+    [Fact]
+    public void Supports_multiple_environments()
+    {
+        var env = new GrateEnvironment("BOOYA", "FOOYA");
+        
+        var file1 = FullPath("a_file.ENV.with.BOOYA.sql");
+        var file2 = FullPath("a_file.ENV.with.FOOYA.sql");
+        env.ShouldRun(file1).Should().BeTrue();
+        env.ShouldRun(file2).Should().BeTrue();
+    }
 
     [Fact]
     public void Does_not_run_for_other_environments()


### PR DESCRIPTION
Add support for multiple environments, separated by space, ; or ,
This makes it possible to create orhotogonal environments, and run scripts
that are specific to a combination of environments.

Example: You have:
 * Some scripts that you only run for Customer 1
 * Some scripts that you only run for Customer 2
 * some scripts that you only run for Azure
 * some scripts that you only run for AWS
 * some scripts that you only run for Dev.
 * some scripts that you only run for Test.
 * some scripts that you only run for Prod.

Then, you can combine any of these environments to create a specific environment, to avoid
having to create an environment for each combination.

E.g.:
```
  --env Customer1;Azure
  --env Customer2,Azure
  --env Customer3
  --env Customer1 AWS Dev
  --env Customer1,AWS,Test
  --env Customer2;AWS;QA
  --env Customer2 AWS QA
```
etc.