### PR TITLE
Bug #440: Replaced "TableName" with [TableName] for SQL Server

### DIFF
--- a/src/grate.sqlserver/Infrastructure/SqlServerSyntax.cs
+++ b/src/grate.sqlserver/Infrastructure/SqlServerSyntax.cs
@@ -30,7 +30,7 @@ public readonly struct SqlServerSyntax : ISyntax
                             ALTER DATABASE [{databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE                            
                             DROP DATABASE [{databaseName}] 
                         END";
-    public string TableWithSchema(string schemaName, string tableName) => $"{schemaName}.\"{tableName}\"";
+    public string TableWithSchema(string schemaName, string tableName) => $"{schemaName}.[{tableName}]";
     public string ReturnId => ";SELECT @@IDENTITY";
     public string TimestampType => "datetime";
     public string Quote(string text) => $"\"{text}\"";

--- a/unittests/SqlServer/Reported_issues/Quoted_Identifier_440.cs
+++ b/unittests/SqlServer/Reported_issues/Quoted_Identifier_440.cs
@@ -1,0 +1,48 @@
+﻿using grate.Configuration;
+using SqlServer.TestInfrastructure;
+using TestCommon.Generic.Running_MigrationScripts;
+using TestCommon.TestInfrastructure;
+
+namespace SqlServer.Reported_issues;
+
+// ReSharper disable once InconsistentNaming
+[Collection(nameof(SqlServerGrateTestContext))]
+public class Quoted_Identifier_440(SqlServerGrateTestContext context, ITestOutputHelper testOutput) : MigrationsScriptsBase(context, testOutput)
+{
+    const string sql = """
+                       SET QUOTED_IDENTIFIER OFF
+                       GO
+                       CREATE PROCEDURE [do_something_or_something_else]
+                           @Blip            nvarchar(128),
+                           @Blop            nvarchar(128)
+                       AS
+                       BEGIN
+                           SELECT @@VERSION;
+                       END
+                       GO
+                       """;
+    
+    [Fact]
+    public async Task Setting_QUOTED_IDENTIFIER_OFF_in_a_script_does_not_mess_up_migration()
+    {
+        var db = TestConfig.RandomDatabase();
+
+        var parent = CreateRandomTempDirectory();
+        var knownFolders = FoldersConfiguration.Default();
+       
+        var path = new DirectoryInfo(Path.Combine(parent.ToString(), knownFolders[KnownFolderKeys.Sprocs]!.Path));
+
+        WriteSql(path, "some_sproc.sql", sql);
+        
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(knownFolders)
+            .WithSqlFilesDirectory(parent)
+            .Build();
+
+        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        {
+            await migrator.Migrate();
+        }
+    }
+}

--- a/unittests/SqlServer/Reported_issues/Run_after_create_database_232.cs
+++ b/unittests/SqlServer/Reported_issues/Run_after_create_database_232.cs
@@ -5,7 +5,7 @@ using TestCommon.Generic.Running_MigrationScripts;
 using TestCommon.TestInfrastructure;
 using static grate.Configuration.KnownFolderKeys;
 
-namespace SqlServer.Running_MigrationScripts;
+namespace SqlServer.Reported_issues;
 
 // ReSharper disable once InconsistentNaming
 /// <summary>
@@ -13,7 +13,7 @@ namespace SqlServer.Running_MigrationScripts;
 /// Create tests to reproduce the issue and then fix the issue, and keep the test to ensure it doesn't regress.
 /// </summary>
 [Collection(nameof(SqlServerGrateTestContext))]
-public class Real_world_issues(SqlServerGrateTestContext context, ITestOutputHelper testOutput) : MigrationsScriptsBase(context, testOutput)
+public class Run_after_create_database_232(SqlServerGrateTestContext context, ITestOutputHelper testOutput) : MigrationsScriptsBase(context, testOutput)
 {
     private const string Bug232Sql = @"
 ALTER DATABASE {{DatabaseName}} SET ALLOW_SNAPSHOT_ISOLATION ON;


### PR DESCRIPTION
Bug #440: Replaced "ScriptsRun" with [ScriptsRun] (and others) for SQL Server to avoid issues with QUOTED_IDENTIFIER OFF