### PR TITLE
Fix documentation typo: gratesettings => grate_settings

### DIFF
--- a/docs/ConfigurationOptions/ResponseFiles.md
+++ b/docs/ConfigurationOptions/ResponseFiles.md
@@ -18,7 +18,7 @@ For example, if you created a `grate_settings.rsp` file with the following conte
 --ut=my_token=myvalue
 ```
 
-and ran it via `grate @./gratesettings.rsp` it would be the equivalent to the following command:
+and ran it via `grate @./grate_settings.rsp` it would be the equivalent to the following command:
 ``` bash
 grate -cs SomeConnectionString -f ./db --env DEV --drop --version 1.0 --ut=my_token=myvalue
 ```


### PR DESCRIPTION
Minor fix to documentation typo.

In [docs/ConfigurationOptions/ResponseFiles.md](https://github.com/erikbra/grate/blob/main/docs/ConfigurationOptions/ResponseFiles.md) the example response file is named first `grate_settings.rsp` then `gratesettings.rsp`. Testing on Ubuntu showed that this would result in the following error:

```
Response file not found './gratesettings.rsp'.
```

(Not being familiar with ResponseFiles, this seemed worth testing, in case there was some kind of "remove all underscores in a filename" magic going on.)

