### PR TITLE
Bug #512: Grate internal scripts fail when using CreateDatabase scripts

### DIFF
--- a/src/grate.core/Migration/DbMigrator.cs
+++ b/src/grate.core/Migration/DbMigrator.cs
@@ -407,5 +407,5 @@ internal record DbMigrator : IDbMigrator
         GC.SuppressFinalize(this);
     }
 
-    object ICloneable.Clone() => this with { Database = (IDatabase) Database.Clone() };
+    object ICloneable.Clone() => this with { Database = (IDatabase) Database.Clone(), _tokens = null };
 }


### PR DESCRIPTION
* Make sure the replacement tokens are reset when running the internal migrations