### PR TITLE
Bug #513: Changed to MySQL compatible syntax on 'ADD COLUMN IF NOT EXISTS' in internal grate tables

### DIFF
--- a/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE {{SchemaName}}_{{VersionTable}}
-ADD COLUMN IF NOT EXISTS status varchar(50) NULL;

--- a/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/01b_version_add_status_column.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/01b_version_add_status_column.sql
@@ -1,0 +1,17 @@
+-- The MariaDB version below is more elegant, but it is not compatible with MySQL.
+-- ALTER TABLE {{SchemaName}}_{{VersionTable}}
+-- ADD COLUMN IF NOT EXISTS status varchar(50) NULL;;
+
+-- MySQL does not support the IF NOT EXISTS clause for ADD COLUMN, as MariaDB does.
+-- So, instead of the MariaDB version, we need to use a handler to ignore the error if the column already exists.
+-- This is a bit of a hack, but it works.
+-- The MariaDB version is more elegant, but it is not compatible with MySQL.
+CREATE PROCEDURE create_{{SchemaName}}_{{VersionTable}}()
+BEGIN
+    DECLARE CONTINUE HANDLER FOR 1060 BEGIN END;
+    ALTER TABLE {{SchemaName}}_{{VersionTable}}
+    ADD COLUMN status varchar(50) NULL;
+END;
+CALL create_{{SchemaName}}_{{VersionTable}}();
+
+DROP PROCEDURE create_{{SchemaName}}_{{VersionTable}}


### PR DESCRIPTION
* Fixed syntax so that it is MySQL compatible
* Renamed MariaDb GrateStructure/up/01_version_add_status_column.sql to 01b_version_add_status_column.sql to avoid issues with changed one-time scripts (actually running it is idempotent)

fixes #513 