### PR TITLE
Chore: Set verbosity to very low (Warning) on running internal migrations

### DIFF
--- a/src/grate.core/Configuration/GrateConfiguration.cs
+++ b/src/grate.core/Configuration/GrateConfiguration.cs
@@ -137,8 +137,6 @@ public record GrateConfiguration
 
     private static DirectoryInfo CurrentDirectory => new(Directory.GetCurrentDirectory());
 
-    public LogLevel Verbosity { get; init; } = LogLevel.Information;
-
     /// <summary>
     /// If true grate will not store script text in the database to save space in small/embedded databases.
     /// </summary>

--- a/src/grate.core/Migration/IDbMigrator.cs
+++ b/src/grate.core/Migration/IDbMigrator.cs
@@ -1,5 +1,6 @@
 ﻿using grate.Configuration;
 using grate.Infrastructure;
+using Microsoft.Extensions.Logging;
 
 namespace grate.Migration;
 
@@ -7,6 +8,7 @@ internal interface IDbMigrator : IAsyncDisposable, ICloneable
 {
     GrateConfiguration Configuration { get; set; }
     IDatabase Database { get; set; }
+    ILogger Logger { get; set; }
     Task InitializeConnections();
     Task<bool> CreateDatabase();
 

--- a/src/grate.core/grate.core.csproj
+++ b/src/grate.core/grate.core.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>grate</RootNamespace>
     <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("O"))</SourceRevisionId>
-    
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/grate.mariadb/grate.mariadb.csproj
+++ b/src/grate.mariadb/grate.mariadb.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/grate.oracle/grate.oracle.csproj
+++ b/src/grate.oracle/grate.oracle.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/grate.postgresql/grate.postgresql.csproj
+++ b/src/grate.postgresql/grate.postgresql.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/grate.sqlite/grate.sqlite.csproj
+++ b/src/grate.sqlite/grate.sqlite.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/grate.sqlserver/grate.sqlserver.csproj
+++ b/src/grate.sqlserver/grate.sqlserver.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/grate/Configuration/CommandLineGrateConfiguration.cs
+++ b/src/grate/Configuration/CommandLineGrateConfiguration.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace grate.Configuration;
 
 internal record CommandLineGrateConfiguration : GrateConfiguration
@@ -6,5 +8,6 @@ internal record CommandLineGrateConfiguration : GrateConfiguration
     /// Database type to use.
     /// </summary>
     public DatabaseType DatabaseType { get; set; }
-    
+
+    public LogLevel Verbosity { get; init; } = LogLevel.Information;
 }

--- a/src/grate/Program.cs
+++ b/src/grate/Program.cs
@@ -125,6 +125,7 @@ public static class Program
                 options.FormatterName = GrateConsoleFormatter.FormatterName;
                 options.LogToStandardErrorThreshold = LogLevel.Warning;
             })
+            .AddFilter("Grate.Migration.Internal", LogLevel.Critical)
             .SetMinimumLevel(config.Verbosity)
             .AddConsoleFormatter<GrateConsoleFormatter, SimpleConsoleFormatterOptions>());
         

--- a/src/grate/grate.csproj
+++ b/src/grate/grate.csproj
@@ -66,7 +66,9 @@
     <InternalsVisibleTo Include="Docker.Oracle" />
     <InternalsVisibleTo Include="Docker.PostgreSQL" />
     <InternalsVisibleTo Include="Docker.Sqlite" />
-    <InternalsVisibleTo Include="Docker.SqlServer" />   
+    <InternalsVisibleTo Include="Docker.SqlServer" />
+    
+    <InternalsVisibleTo Include="TestCommon" />
   </ItemGroup>
   
   <ItemGroup>

--- a/unittests/Basic_tests/Basic_tests.csproj
+++ b/unittests/Basic_tests/Basic_tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Basic_tests</RootNamespace>
   </PropertyGroup>

--- a/unittests/Basic_tests/GrateMigrator_.cs
+++ b/unittests/Basic_tests/GrateMigrator_.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Basic_tests.Infrastructure;
+using FluentAssertions;
 using grate.Configuration;
 using grate.Infrastructure;
 using grate.Migration;
@@ -10,43 +11,65 @@ namespace Basic_tests;
 // ReSharper disable once InconsistentNaming
 public class GrateMigrator_
 {
-    private IDatabase _database = Substitute.For<IDatabase>();
-    private GrateConfiguration? _config = new GrateConfiguration();
+    private readonly IDatabase _database = Substitute.For<IDatabase>();
+    private readonly GrateConfiguration? _config = new GrateConfiguration();
 
     [Fact]
     public void Setting_the_config_does_not_change_the_original()
     {
         var config = new GrateConfiguration() { ConnectionString = "Server=server1" };
         var dbMigrator = new DbMigrator(_database, null!, null!, config);
-        
-        var grateMigrator = new GrateMigrator(null!, dbMigrator);
-        
+
+        var grateMigrator = new GrateMigrator(new MockGrateLoggerFactory(), dbMigrator);
+
         grateMigrator.Configuration.Should().BeEquivalentTo(config);
-        
+
         var changedConfig = config with { ConnectionString = "Server=server2" };
         var changedMigrator = grateMigrator.WithConfiguration(changedConfig);
-        
+
         grateMigrator.Configuration.ConnectionString.Should().Be("Server=server1");
         changedMigrator.Configuration.ConnectionString.Should().Be("Server=server2");
     }
-    
+
     [Fact]
     public void Setting_the_Database_does_not_change_the_original()
     {
         _database.DatabaseName.Returns("server1");
         var dbMigrator = new DbMigrator(_database, null!, null!, _config);
-        
-        var grateMigrator = new GrateMigrator(null!, dbMigrator);
-        
+
+        var grateMigrator = new GrateMigrator(new MockGrateLoggerFactory(), dbMigrator);
+
         grateMigrator.Database.DatabaseName.Should().Be("server1");
-        
+
         var changedDatabase = Substitute.For<IDatabase>();
         changedDatabase.DatabaseName.Returns("server2");
-        
+
         var changedMigrator = grateMigrator.WithDatabase(changedDatabase) as GrateMigrator;
 
         grateMigrator.Database.DatabaseName.Should().Be("server1");
         changedMigrator!.Database.DatabaseName.Should().Be("server2");
     }
     
+    [Theory]
+    [MemberData(nameof(Environments))]
+    public void Logger_has_the_correct_LogCategory(GrateEnvironment environment, string logCategory)
+    {
+        var config = new GrateConfiguration() { Environment = environment };
+        var dbMigrator = new DbMigrator(_database, null!, null!, config);
+        
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        _ = new GrateMigrator(loggerFactory, dbMigrator);
+
+        loggerFactory.Received().CreateLogger(logCategory);
+    }
+    
+    public static TheoryData<GrateEnvironment, string> Environments() => new()
+    {
+        { GrateEnvironment.Internal, "Grate.Migration.Internal" },
+        { GrateEnvironment.InternalBootstrap, "Grate.Migration.Internal" },
+        { new GrateEnvironment("Development"), "Grate.Migration" },
+        { new GrateEnvironment("Test"), "Grate.Migration" },
+        { new GrateEnvironment("Production"), "Grate.Migration" },
+    };
+
 }

--- a/unittests/Basic_tests/Infrastructure/MockDbMigrator.cs
+++ b/unittests/Basic_tests/Infrastructure/MockDbMigrator.cs
@@ -2,6 +2,7 @@
 using grate.Infrastructure;
 using grate.Migration;
 using grate.Sqlite.Migration;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace Basic_tests.Infrastructure;
@@ -14,6 +15,8 @@ public record MockDbMigrator: IDbMigrator
 
     public GrateConfiguration Configuration { get; set; } = null!;
     public IDatabase Database { get; set; } = Substitute.For<IDatabase>();
+    public ILogger Logger { get; set; } = Substitute.For<ILogger>();
+
     public  Task InitializeConnections()
     {
         return Task.CompletedTask;

--- a/unittests/Basic_tests/Infrastructure/MockGrateLogger.cs
+++ b/unittests/Basic_tests/Infrastructure/MockGrateLogger.cs
@@ -25,5 +25,28 @@ public record MockGrateLogger: ILogger<GrateMigrator>
     }
     
     public IList<string> LoggedMessages { get; } = new List<string>();
-    
+}
+
+public record MockGrateLoggerFactory: ILoggerFactory
+{
+    private readonly MockGrateLogger _logger;
+
+    public MockGrateLoggerFactory(MockGrateLogger? logger = null)
+    {
+        _logger = logger ?? new MockGrateLogger();
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _logger;
+    }
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/unittests/Basic_tests/Migration.cs
+++ b/unittests/Basic_tests/Migration.cs
@@ -9,17 +9,19 @@ namespace Basic_tests;
 public class Migration
 {
     private readonly MockGrateLogger  _logger;
+    private readonly MockGrateLoggerFactory _loggerFactory;
 
     public Migration()
     {
         _logger = new MockGrateLogger();
+        _loggerFactory = new MockGrateLoggerFactory(_logger);
     }
 
     [Fact]
-    public async Task Does_not_output_no_sql_run_in_dryrun_mode()
+    public async Task Does_not_output_qny_sql_run_in_dryrun_mode()
     {
         var dbMigrator = GetDbMigrator(true);
-        var migrator = new GrateMigrator(_logger, dbMigrator);
+        var migrator = new GrateMigrator(_loggerFactory, dbMigrator);
         await migrator.Migrate();
         _logger.LoggedMessages.Should().NotContain(" No sql run, either an empty folder, or all files run against destination previously.");
     }
@@ -28,7 +30,7 @@ public class Migration
     public async Task Outputs_no_sql_run_in_live_mode()
     {
         var dbMigrator = GetDbMigrator(false);
-        var migrator = new GrateMigrator(_logger, dbMigrator);
+        var migrator = new GrateMigrator(_loggerFactory, dbMigrator);
         await migrator.Migrate();
         _logger.LoggedMessages.Should().Contain(" No sql run, either an empty folder, or all files run against destination previously.");
     }

--- a/unittests/CommandLine/CommandLine.Common/CommandLine.Common.csproj
+++ b/unittests/CommandLine/CommandLine.Common/CommandLine.Common.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
 

--- a/unittests/CommandLine/CommandLine.MariaDB/CommandLine.MariaDB.csproj
+++ b/unittests/CommandLine/CommandLine.MariaDB/CommandLine.MariaDB.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/CommandLine/CommandLine.Oracle/CommandLine.Oracle.csproj
+++ b/unittests/CommandLine/CommandLine.Oracle/CommandLine.Oracle.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/CommandLine/CommandLine.PostgreSQL/CommandLine.PostgreSQL.csproj
+++ b/unittests/CommandLine/CommandLine.PostgreSQL/CommandLine.PostgreSQL.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/CommandLine/CommandLine.SqlServer/CommandLine.SqlServer.csproj
+++ b/unittests/CommandLine/CommandLine.SqlServer/CommandLine.SqlServer.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/CommandLine/CommandLine.Sqlite/CommandLine.Sqlite.csproj
+++ b/unittests/CommandLine/CommandLine.Sqlite/CommandLine.Sqlite.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/Docker/Docker.Common/Docker.Common.csproj
+++ b/unittests/Docker/Docker.Common/Docker.Common.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
 

--- a/unittests/Docker/Docker.Common/TestInfrastructure/DockerGrateMigrator.cs
+++ b/unittests/Docker/Docker.Common/TestInfrastructure/DockerGrateMigrator.cs
@@ -108,7 +108,6 @@ public record DockerGrateMigrator(
                 // Need to overwrite the output path, as we don't have the same tmp folders on the host as in the container,
                 // and the root file system is read-only in the test container
                 OutputPath = new DirectoryInfo(Path.Combine("/tmp", "grate-tests-output", Directory.CreateTempSubdirectory().Name)),
-                Verbosity = LogLevel.Debug
             }
         };
     }

--- a/unittests/Docker/Docker.MariaDB/Docker.MariaDB.csproj
+++ b/unittests/Docker/Docker.MariaDB/Docker.MariaDB.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/Docker/Docker.Oracle/Docker.Oracle.csproj
+++ b/unittests/Docker/Docker.Oracle/Docker.Oracle.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/Docker/Docker.PostgreSQL/Docker.PostgreSQL.csproj
+++ b/unittests/Docker/Docker.PostgreSQL/Docker.PostgreSQL.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/Docker/Docker.SqlServer/Docker.SqlServer.csproj
+++ b/unittests/Docker/Docker.SqlServer/Docker.SqlServer.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/Docker/Docker.Sqlite/Docker.Sqlite.csproj
+++ b/unittests/Docker/Docker.Sqlite/Docker.Sqlite.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/unittests/MariaDB/MariaDB.csproj
+++ b/unittests/MariaDB/MariaDB.csproj
@@ -1,22 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+      <IsTestProject>true</IsTestProject>
+      <IsPackable>false</IsPackable>
+      <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="XunitXml.TestLogger" />
-        <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="Testcontainers.MariaDb" />
-        <PackageReference Include="Xunit.DependencyInjection" />
-        <PackageReference Include="Xunit.DependencyInjection.Logging" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="xunit"/>
+      <PackageReference Include="xunit.runner.visualstudio"/>
+      <PackageReference Include="XunitXml.TestLogger" />
+      <PackageReference Include="coverlet.collector" />
+      <PackageReference Include="Testcontainers.MariaDb" />
+      <PackageReference Include="Xunit.DependencyInjection" />
+      <PackageReference Include="Xunit.DependencyInjection.Logging" />
     </ItemGroup>
 
     <ItemGroup>

--- a/unittests/Oracle/Oracle.csproj
+++ b/unittests/Oracle/Oracle.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+      <IsTestProject>true</IsTestProject>
+      <IsPublishable>false</IsPublishable>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/unittests/Oracle/TestInfrastructure/OracleGrateTestContext.cs
+++ b/unittests/Oracle/TestInfrastructure/OracleGrateTestContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using Docker.DotNet.Models;
 using grate.Infrastructure;
 using grate.Migration;

--- a/unittests/PostgreSQL/PostgreSQL.csproj
+++ b/unittests/PostgreSQL/PostgreSQL.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+      <IsTestProject>true</IsTestProject>
+      <IsPublishable>false</IsPublishable>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/unittests/SqlServer/SqlServer.csproj
+++ b/unittests/SqlServer/SqlServer.csproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+      <IsTestProject>true</IsTestProject>
+      <IsPublishable>false</IsPublishable>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
-  <ItemGroup>
+    <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
       <PackageReference Include="xunit"/>
       <PackageReference Include="xunit.runner.visualstudio"/>
@@ -17,7 +19,7 @@
       <PackageReference Include="Testcontainers.MsSql" />
       <PackageReference Include="Xunit.DependencyInjection" />
       <PackageReference Include="Xunit.DependencyInjection.Logging" />
-  </ItemGroup>
+    </ItemGroup>
 
   <ItemGroup>
       <ProjectReference Include="..\..\src\grate\grate.csproj" />

--- a/unittests/SqlServer/TestInfrastructure/SqlServerGrateTestContext.cs
+++ b/unittests/SqlServer/TestInfrastructure/SqlServerGrateTestContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using grate.Infrastructure;
 using grate.Migration;
 using grate.SqlServer.Infrastructure;

--- a/unittests/SqlServerCaseSensitive/SqlServerCaseSensitive.csproj
+++ b/unittests/SqlServerCaseSensitive/SqlServerCaseSensitive.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+      <IsTestProject>true</IsTestProject>
+      <IsPublishable>false</IsPublishable>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
   <ItemGroup>

--- a/unittests/Sqlite/Sqlite.csproj
+++ b/unittests/Sqlite/Sqlite.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
+      <IsTestProject>true</IsTestProject>
+      <IsPublishable>false</IsPublishable>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
   <ItemGroup>

--- a/unittests/TestCommon/Startup.cs
+++ b/unittests/TestCommon/Startup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using DotNet.Testcontainers.Builders;
 using grate.Configuration;
 using Microsoft.Extensions.Configuration;
@@ -38,8 +39,13 @@ public abstract class Startup
         RegisterTestDatabase(services, context.Configuration);
     }
     
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] 
     protected abstract Type TestContainerDatabaseType { get; }
+    
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] 
     protected abstract Type ExternalTestDatabaseType { get; }
+    
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] 
     protected abstract Type TestContextType { get; }
 
     // ReSharper disable once UnassignedGetOnlyAutoProperty

--- a/unittests/TestCommon/Startup.cs
+++ b/unittests/TestCommon/Startup.cs
@@ -1,11 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
 using DotNet.Testcontainers.Builders;
-using grate.Configuration;
+using grate.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using TestCommon.TestInfrastructure;
 
 namespace TestCommon;
@@ -24,7 +25,13 @@ public abstract class Startup
         services.AddLogging(
                 lb => lb
                     .AddXUnit()
-                    .AddConsole()
+                    .AddConsole(options =>
+                    {
+                        options.FormatterName = GrateConsoleFormatter.FormatterName;
+                        options.LogToStandardErrorThreshold = LogLevel.Critical;
+                    })
+                    .AddFilter("Grate.Migration.Internal", LogLevel.Critical)
+                    .AddConsoleFormatter<GrateConsoleFormatter, SimpleConsoleFormatterOptions>()
                     .SetMinimumLevel(TestConfig.GetLogLevel())
             );
         

--- a/unittests/TestCommon/Startup_T.cs
+++ b/unittests/TestCommon/Startup_T.cs
@@ -1,16 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
 using TestCommon.TestInfrastructure;
 
 namespace TestCommon;
 
 public abstract class Startup<
-    TTestContainerDatabase,
-    TExternalDatabase,
-    TGrateTestContext>: Startup
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTestContainerDatabase,
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TExternalDatabase,
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGrateTestContext>: Startup
     where TTestContainerDatabase : ITestDatabase
     where TExternalDatabase : ITestDatabase
     where TGrateTestContext : IGrateTestContext 
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] 
     protected override Type TestContainerDatabaseType => typeof(TTestContainerDatabase);
+    
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] 
     protected override Type ExternalTestDatabaseType => typeof(TExternalDatabase);
+    
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] 
     protected override Type TestContextType => typeof(TGrateTestContext);
 }

--- a/unittests/TestCommon/TestCommon.csproj
+++ b/unittests/TestCommon/TestCommon.csproj
@@ -5,7 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <IsTestProject>false</IsTestProject>
+    <NoWarn>IL2072;IL2075;IL2026</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/unittests/TestCommon/TestInfrastructure/GrateTestContext.cs
+++ b/unittests/TestCommon/TestInfrastructure/GrateTestContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using Dapper;
 using grate.Infrastructure;
 using grate.Migration;
@@ -41,7 +42,9 @@ public abstract record GrateTestContext(IGrateMigrator Migrator, ITestDatabase T
 
     public abstract ISyntax Syntax { get; }
     public abstract Type DbExceptionType { get; }
+    
     public abstract Type DatabaseType { get; }
+    
     public abstract bool SupportsTransaction { get; }
     public abstract SqlStatements Sql { get; }
     public abstract string ExpectedVersionPrefix { get; }

--- a/unittests/TestCommon/TestInfrastructure/IGrateTestContext.cs
+++ b/unittests/TestCommon/TestInfrastructure/IGrateTestContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using grate.Configuration;
 using grate.Infrastructure;


### PR DESCRIPTION
After introducing the internal migrations with grate itself, the output became very cluttered, and confusing, as it looks like the migration is looping, when it's really only running the internal grate migrations first. But, this is an internal grate matter, and shouldn't bother the end-users. Change the logging verbosity of the internal migrations to `Warning`, to avoid logging anything except when stuff fails.

Possible breaking change: The `Verbosity` property on the `GrateConfiguration` is removed. It wasn't working, so if someone has used it, please forgive any compile errors due to this.