### PR TITLE
Create logger after instantiating DbMigrator to make sure the new con…

### DIFF
--- a/src/grate.core/Migration/GrateMigrator.cs
+++ b/src/grate.core/Migration/GrateMigrator.cs
@@ -22,10 +22,11 @@ internal record GrateMigrator : IGrateMigrator
         get => DbMigrator.Configuration;
         private init
         {
-            _logger = _loggerFactory.CreateLogger(LogCategory);
-            
+            DbMigrator = (IDbMigrator) DbMigrator.Clone();
             DbMigrator = (IDbMigrator) DbMigrator.Clone();
             DbMigrator.Configuration = value;
+
+            _logger = _loggerFactory.CreateLogger(LogCategory);
             DbMigrator.Logger = _logger;
         }
     }

--- a/src/grate.core/Migration/GrateMigrator.cs
+++ b/src/grate.core/Migration/GrateMigrator.cs
@@ -23,7 +23,6 @@ internal record GrateMigrator : IGrateMigrator
         private init
         {
             DbMigrator = (IDbMigrator) DbMigrator.Clone();
-            DbMigrator = (IDbMigrator) DbMigrator.Clone();
             DbMigrator.Configuration = value;
 
             _logger = _loggerFactory.CreateLogger(LogCategory);


### PR DESCRIPTION
Create logger after instantiating DbMigrator to make sure the new configuration is used to determine if grate is running internally, yes or no. This is regarding issue https://github.com/erikbra/grate/issues/519.