### PR TITLE
Update TestContainers to 3.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,11 +25,11 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="XunitXml.TestLogger" Version="3.1.20" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Testcontainers" Version="3.8.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="3.8.0" />
-    <PackageVersion Include="Testcontainers.MariaDb" Version="3.8.0" />
-    <PackageVersion Include="Testcontainers.Oracle" Version="3.8.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="3.8.0" />
+    <PackageVersion Include="Testcontainers" Version="3.9.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="3.9.0" />
+    <PackageVersion Include="Testcontainers.MariaDb" Version="3.9.0" />
+    <PackageVersion Include="Testcontainers.Oracle" Version="3.9.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="3.9.0" />
     <PackageVersion Include="Xunit.DependencyInjection" Version="9.3.0" />
     <PackageVersion Include="Xunit.DependencyInjection.Logging" Version="9.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />


### PR DESCRIPTION
Combine all the Dependabot PRs for upgrading TestContainers to 3.9.0 to one single one, to avoid version conflicts between the different packages