### PR TITLE
Remove breaking spaces

### DIFF
--- a/src/grate.core/Configuration/FoldersConfiguration.cs
+++ b/src/grate.core/Configuration/FoldersConfiguration.cs
@@ -37,7 +37,7 @@ internal class FoldersConfiguration : Dictionary<string, MigrationsFolder?>, IFo
         {
             { KnownFolderKeys.BeforeMigration, new MigrationsFolder("BeforeMigration", folderNames.BeforeMigration, EveryTime, TransactionHandling: TransactionHandling.Autonomous) },
             { KnownFolderKeys.AlterDatabase , new MigrationsFolder("AlterDatabase", folderNames.AlterDatabase, AnyTime, ConnectionType.Admin, TransactionHandling.Autonomous) },
-            { KnownFolderKeys.RunAfterCreateDatabase, new MigrationsFolder("Run After Create Database", folderNames.RunAfterCreateDatabase, AnyTime) },
+            { KnownFolderKeys.RunAfterCreateDatabase, new MigrationsFolder("RunAfterCreateDatabase", folderNames.RunAfterCreateDatabase, AnyTime) },
             { KnownFolderKeys.RunBeforeUp,  new MigrationsFolder("Run Before Update", folderNames.RunBeforeUp, AnyTime) },
             { KnownFolderKeys.Up, new MigrationsFolder("Update", folderNames.Up, Once) },
             { KnownFolderKeys.RunFirstAfterUp, new MigrationsFolder("Run First After Update", folderNames.RunFirstAfterUp, AnyTime) },


### PR DESCRIPTION
Hello, this is a possible solution to issue #536 :)

It looks like this may be a more general problem than just one folder name, and it requires a separate folder identifier and a user-friendly folder name. Please let me know if you would like me to prepare such changes.

But at the same time, `Run After Create Database` is a specific folder, and perhaps it can be fixed without major changes to the project. At least for now.

 