### PR TITLE
Bug #557: Fixed new (similar) bug if grate schemas/tables exist with different casing for PostgreSQL

### DIFF
--- a/src/grate.core/Migration/GrateMigrator.cs
+++ b/src/grate.core/Migration/GrateMigrator.cs
@@ -610,7 +610,10 @@ internal record GrateMigrator : IGrateMigrator
             [
                 "ScriptsRunTable=GrateScriptsRun",
                 "ScriptsRunErrorsTable=GrateScriptsRunErrors",
-                "VersionTable=GrateVersion"
+                "VersionTable=GrateVersion",
+                "ScriptsRunTableLowerCase=grateversion",
+                "ScriptsRunErrorsTableLowerCase=gratescriptrunerrors",
+                "VersionTableLowerCase=grateversion"
             ],
             DeferWritingToRunTables = true,
             Environment = GrateEnvironment.InternalBootstrap,
@@ -664,7 +667,10 @@ internal record GrateMigrator : IGrateMigrator
             UserTokens = [
                 $"ScriptsRunTable={thisConfig.ScriptsRunTableName}",
                 $"ScriptsRunErrorsTable={thisConfig.ScriptsRunErrorsTableName}",
-                $"VersionTable={thisConfig.VersionTableName}"
+                $"VersionTable={thisConfig.VersionTableName}",
+                $"ScriptsRunTableLowerCase={thisConfig.ScriptsRunTableName.ToLower()}",
+                $"ScriptsRunErrorsTableLowerCase={thisConfig.ScriptsRunErrorsTableName.ToLower()}",
+                $"VersionTableLowerCase={thisConfig.VersionTableName.ToLower()}"
             ],
             
             Environment = GrateEnvironment.Internal

--- a/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/00_02_fix_version_table_casing.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/00_02_fix_version_table_casing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS `{{SchemaName}}_{{VersionTableLowerCase}}`
+RENAME TO `{{SchemaName}}_{{VersionTable}}`

--- a/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrun_table_casing.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrun_table_casing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS `{{SchemaName}}_{{ScriptsRunTableLowerCase}}`
+RENAME TO `{{SchemaName}}_{{ScriptsRunTable}}`

--- a/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrunerrors_table_casing.sql
+++ b/src/grate.mariadb/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrunerrors_table_casing.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS `{{SchemaName}}_{{ScriptsRunErrorsTableLowerCase}}`
+RENAME TO `{{SchemaName}}_{{ScriptsRunErrorsTable}}`

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_01_fix_schema_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_01_fix_schema_casing.sql
@@ -1,0 +1,7 @@
+DO LANGUAGE plpgsql
+$$
+BEGIN
+    ALTER SCHEMA {{SchemaName}} RENAME TO "{{SchemaName}}";
+EXCEPTION WHEN duplicate_schema or invalid_schema_name THEN
+END;
+$$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_02_fix_version_table_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_02_fix_version_table_casing.sql
@@ -1,7 +1,7 @@
 DO LANGUAGE plpgsql
 $$
 BEGIN
-    ALTER TABLE "{{SchemaName}}".{{VersionTable}} RENAME TO "{{VersionTable}}";
+    ALTER TABLE "{{SchemaName}}"."{{VersionTableLowerCase}}" RENAME TO "{{VersionTable}}";
 EXCEPTION WHEN undefined_table or duplicate_table THEN
 END;
 $$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_02_fix_version_table_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_02_fix_version_table_casing.sql
@@ -1,0 +1,7 @@
+DO LANGUAGE plpgsql
+$$
+BEGIN
+    ALTER TABLE "{{SchemaName}}".{{VersionTable}} RENAME TO "{{VersionTable}}";
+EXCEPTION WHEN undefined_table or duplicate_table THEN
+END;
+$$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrun_table_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrun_table_casing.sql
@@ -1,0 +1,7 @@
+DO LANGUAGE plpgsql
+$$
+BEGIN
+    ALTER TABLE "{{SchemaName}}".{{ScriptsRunTable}} RENAME TO "{{ScriptsRunTable}}";
+EXCEPTION WHEN undefined_table or duplicate_table THEN
+END;
+$$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrun_table_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrun_table_casing.sql
@@ -1,7 +1,7 @@
 DO LANGUAGE plpgsql
 $$
 BEGIN
-    ALTER TABLE "{{SchemaName}}".{{ScriptsRunTable}} RENAME TO "{{ScriptsRunTable}}";
+    ALTER TABLE "{{SchemaName}}"."{{ScriptsRunTableLowerCase}}" RENAME TO "{{ScriptsRunTable}}";
 EXCEPTION WHEN undefined_table or duplicate_table THEN
 END;
 $$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrunerrors_table_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrunerrors_table_casing.sql
@@ -1,7 +1,7 @@
 DO LANGUAGE plpgsql
 $$
 BEGIN
-    ALTER TABLE "{{SchemaName}}".{{ScriptsRunErrorsTable}} RENAME TO "{{ScriptsRunErrorsTable}}";
+    ALTER TABLE "{{SchemaName}}"."{{ScriptsRunErrorsTableLowerCase}}" RENAME TO "{{ScriptsRunErrorsTable}}";
 EXCEPTION WHEN undefined_table or duplicate_table THEN
 END;
 $$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrunerrors_table_casing.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/00_03_fix_scriptsrunerrors_table_casing.sql
@@ -1,0 +1,7 @@
+DO LANGUAGE plpgsql
+$$
+BEGIN
+    ALTER TABLE "{{SchemaName}}".{{ScriptsRunErrorsTable}} RENAME TO "{{ScriptsRunErrorsTable}}";
+EXCEPTION WHEN undefined_table or duplicate_table THEN
+END;
+$$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,2 +1,20 @@
 ALTER TABLE "{{SchemaName}}"."{{VersionTable}}"
 ADD COLUMN IF NOT EXISTS status varchar(50) NULL;
+
+-- DO LANGUAGE plpgsql
+-- $$
+-- BEGIN
+--     ALTER TABLE "{{SchemaName}}"."{{VersionTable}}"
+--     ADD COLUMN IF NOT EXISTS status varchar(50) NULL;
+-- EXCEPTION WHEN OTHERS THEN
+-- END;
+-- $$;
+-- 
+-- DO LANGUAGE plpgsql
+-- $$
+-- BEGIN
+-- ALTER TABLE {{SchemaName}}.{{VersionTable}}
+--     ADD COLUMN IF NOT EXISTS status varchar(50) NULL;
+-- EXCEPTION WHEN OTHERS THEN
+-- END;
+-- $$;

--- a/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
+++ b/src/grate.postgresql/Bootstrapping/Sql/GrateStructure/up/01_version_add_status_column.sql
@@ -1,20 +1,2 @@
 ALTER TABLE "{{SchemaName}}"."{{VersionTable}}"
 ADD COLUMN IF NOT EXISTS status varchar(50) NULL;
-
--- DO LANGUAGE plpgsql
--- $$
--- BEGIN
---     ALTER TABLE "{{SchemaName}}"."{{VersionTable}}"
---     ADD COLUMN IF NOT EXISTS status varchar(50) NULL;
--- EXCEPTION WHEN OTHERS THEN
--- END;
--- $$;
--- 
--- DO LANGUAGE plpgsql
--- $$
--- BEGIN
--- ALTER TABLE {{SchemaName}}.{{VersionTable}}
---     ADD COLUMN IF NOT EXISTS status varchar(50) NULL;
--- EXCEPTION WHEN OTHERS THEN
--- END;
--- $$;

--- a/unittests/Sqlite/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/Sqlite/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -1,4 +1,5 @@
-﻿using Sqlite.TestInfrastructure;
+﻿using grate.Configuration;
+using Sqlite.TestInfrastructure;
 using TestCommon.TestInfrastructure;
 
 namespace Sqlite.Bootstrapping;
@@ -9,7 +10,6 @@ namespace Sqlite.Bootstrapping;
 public class When_Grate_structure_is_not_latest_version(SqliteGrateTestContext context, ITestOutputHelper testOutput)
     : TestCommon.Generic.Bootstrapping.When_Grate_structure_is_not_latest_version(context, testOutput)
 {
-    [Fact(Skip = "Not able to apply logic to DDL statements for Sqlite")]
-    public override Task The_latest_version_is_applied() => Task.CompletedTask;
+    public override Task The_latest_version_is_applied(string versionTableName) => Task.CompletedTask;
 }
 

--- a/unittests/TestCommon/Generic/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/When_Grate_structure_is_not_latest_version.cs
@@ -12,19 +12,26 @@ using static System.StringSplitOptions;
 namespace TestCommon.Generic.Bootstrapping;
 
 // ReSharper disable once UnusedType.Global
+// ReSharper disable once InconsistentNaming
 public abstract class When_Grate_structure_is_not_latest_version(IGrateTestContext context, ITestOutputHelper testOutput)
     : MigrationsScriptsBase(context, testOutput)
 {
 
-    [Fact]
-    public virtual async Task The_latest_version_is_applied()
+    [Theory]
+    [MemberData(nameof(VersionTableWithDifferentCasings))]
+    public virtual async Task The_latest_version_is_applied(string versionTableName)
     {
         var db = TestConfig.RandomDatabase();
         var parent = CreateRandomTempDirectory();
         
-        // This will create the version table without the status column
+        // This will create the version table without the status column, with different casings
+
+        var cfg = Context.DefaultConfiguration with
+        {
+            VersionTableName = versionTableName
+        };
            
-        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+        var config = GrateConfigurationBuilder.Create(cfg)
             .WithConnectionString(Context.ConnectionString(db))
             .WithFolders(FoldersConfiguration.Default())
             .WithSqlFilesDirectory(parent)
@@ -69,7 +76,6 @@ public abstract class When_Grate_structure_is_not_latest_version(IGrateTestConte
 
         conn.Close();
      
-        
         // Check that the status column is not there
         var tableWithSchema = Context.Syntax.TableWithSchema(config.SchemaName, config.VersionTableName);
         var selectSql = $"SELECT * FROM {tableWithSchema}";
@@ -82,13 +88,24 @@ public abstract class When_Grate_structure_is_not_latest_version(IGrateTestConte
         TryClose(conn);
         columns.Should().NotContain("status".ToUpper());
         
+        // Reset the config to use the default column casings, to make sure that the status column is added even if the
+        // already "existing" tables (which we just created above, with varying casings), are updated, even if the
+        // casing of the default configuration is different from the standard one
+        var standardConfig = config with
+        {
+            VersionTableName = GrateConfiguration.Default.VersionTableName,
+        };
+        
         // Run the migration
-        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        await using (var migrator = Context.Migrator.WithConfiguration(standardConfig))
         {
             await RunMigration(migrator);
         }
         
         // Check that the status column has been added
+        tableWithSchema = Context.Syntax.TableWithSchema(standardConfig.SchemaName, standardConfig.VersionTableName);
+        selectSql = $"SELECT * FROM {tableWithSchema}";
+
         conn = Context.CreateDbConnection(db);
         reader = await conn.ExecuteReaderAsync(selectSql);
         
@@ -99,8 +116,106 @@ public abstract class When_Grate_structure_is_not_latest_version(IGrateTestConte
         
         //await Context.DropDatabase(db);
     }
+    
+    
+    [Theory]
+    [MemberData(nameof(VersionTableWithDifferentCasings))]
+    public virtual async Task The_table_name_casings_are_converted_if_needed(string versionTableName)
+    {
+        var db = TestConfig.RandomDatabase();
+        var parent = CreateRandomTempDirectory();
+        
+        // This will create the version table with the supplied casing
+        var cfg = Context.DefaultConfiguration with
+        {
+            VersionTableName = versionTableName
+        };
+           
+        var config = GrateConfigurationBuilder.Create(cfg)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(FoldersConfiguration.Default())
+            .WithSqlFilesDirectory(parent)
+            .Build();
+        
+        // Create database
+        var password = Context.AdminConnectionString
+            .Split(";", TrimEntries | RemoveEmptyEntries)
+            .SingleOrDefault(entry => entry.StartsWith("Password") || entry.StartsWith("Pwd"))?
+            .Split("=", TrimEntries | RemoveEmptyEntries)
+            .Last();
 
+        var createDatabaseSql = Context.Syntax.CreateDatabase(db, password);
+        using (var adminConn = Context.CreateAdminDbConnection())
+        {
+            await adminConn.ExecuteAsync(createDatabaseSql);
+        }
+        
+        var conn = Context.CreateDbConnection(db);
 
+        // Manually create the script tables, with varying casing (supplied as Theory attributes)
+        var resources = TestInfrastructure.Bootstrapping.GetBootstrapScripts(this.Context.DatabaseType, "Baseline");
+        foreach (var resource in resources)
+        {
+            var resourceText = await TestInfrastructure.Bootstrapping.GetContent(this.Context.DatabaseType.Assembly, resource);
+            
+            resourceText = resourceText.Replace("{{ScriptsRunTable}}", config.ScriptsRunTableName);
+            resourceText = resourceText.Replace("{{ScriptsRunErrorsTable}}", config.ScriptsRunErrorsTableName);
+            resourceText = resourceText.Replace("{{VersionTable}}", config.VersionTableName);
+            resourceText = resourceText.Replace("{{SchemaName}}", config.SchemaName);
+            
+            await conn.ExecuteAsync(resourceText);
+        }
+
+        conn.Close();
+     
+        // Check that the table exists in the DB, with their various casing
+        // - Selecting from the table with a non-existing table name would throw an exception
+        var tableWithSchema = Context.Syntax.TableWithSchema(config.SchemaName, config.VersionTableName);
+        var selectSql = $"SELECT * FROM {tableWithSchema}";
+        
+        conn = Context.CreateDbConnection(db);
+        var reader = await conn.ExecuteReaderAsync(selectSql);
+        
+        var columns = GetColumns(reader).Select(column => column.ToUpper());
+        TryClose(conn);
+        columns.Should().HaveCountGreaterThan(2);
+        
+        // Reset the config to use the default column names, and run the migration. Then, select from the version table
+        // with the default table name, and see that it has been converted to the default casing (if needed by the DB provider),
+        // i.e., we can still select from it.
+        
+        var standardConfig = config with
+        {
+            VersionTableName = GrateConfiguration.Default.VersionTableName,
+        };
+        
+        // Run the migration
+        await using (var migrator = Context.Migrator.WithConfiguration(standardConfig))
+        {
+            await RunMigration(migrator);
+        }
+        
+        // Check that the tables can be selected from, using the standard table names.
+        tableWithSchema = Context.Syntax.TableWithSchema(standardConfig.SchemaName, standardConfig.VersionTableName);
+        selectSql = $"SELECT * FROM {tableWithSchema}";
+
+        conn = Context.CreateDbConnection(db);
+        reader = await conn.ExecuteReaderAsync(selectSql);
+        
+        columns = GetColumns(reader);
+        TryClose(conn);
+        columns.Should().HaveCountGreaterThan(2);
+    }
+
+    public static TheoryData<string> VersionTableWithDifferentCasings()
+    {
+        var def = GrateConfiguration.Default;
+        return new TheoryData<string>
+        {
+            def.VersionTableName,
+            def.VersionTableName.ToLower()
+        };
+    }
 
     private async Task RunMigration(IGrateMigrator migrator)
     {


### PR DESCRIPTION
There was a regression, a similar bug to #245 which was introduced when using SQL scripts to handle the grate table structure versioning (grate the grate), in release 1.7.0.  This should fix it.

Fixes #557 