### PR TITLE
Bug #524: Scripts in internal Grate migration tables are always registered as "run"

### DIFF
--- a/src/grate.core/Migration/AnsiSqlDatabase.cs
+++ b/src/grate.core/Migration/AnsiSqlDatabase.cs
@@ -279,6 +279,17 @@ public abstract record AnsiSqlDatabase : IDatabase
         var prefix = SupportsSchemas ? string.Empty : _syntax.TableWithSchema(schemaName, string.Empty);
         return name?[prefix.Length..];
     }
+   
+    public async Task<bool> GrateInternalTablesAreProperlyLogged()
+    {
+        const string tableName = "GrateScriptsRun";
+
+        string existsSql = $"SELECT 1 FROM {_syntax.TableWithSchema(SchemaName, tableName)} WHERE script_name = '02_create_scripts_run_table.sql'";
+
+        var res = await ExecuteScalarAsync<int?>(ActiveConnection, existsSql);
+        return res is 1;
+    }
+    
 
     protected virtual string ExistsSql(string tableSchema, string fullTableName)
     {

--- a/src/grate.core/Migration/AnsiSqlDatabase.cs
+++ b/src/grate.core/Migration/AnsiSqlDatabase.cs
@@ -286,8 +286,12 @@ public abstract record AnsiSqlDatabase : IDatabase
 
         string existsSql = $"SELECT 1 FROM {_syntax.TableWithSchema(SchemaName, tableName)} WHERE script_name = '02_create_scripts_run_table.sql'";
 
-        var res = await ExecuteScalarAsync<int?>(ActiveConnection, existsSql);
-        return res is 1;
+        if (await ExistingTable(SchemaName, tableName) is { })
+        {
+            var res = await ExecuteScalarAsync<int?>(ActiveConnection, existsSql);
+            return res is 1;
+        }
+        return false;
     }
     
 

--- a/src/grate.core/Migration/IDatabase.cs
+++ b/src/grate.core/Migration/IDatabase.cs
@@ -46,6 +46,7 @@ public interface IDatabase : IAsyncDisposable, ICloneable
         TransactionHandling transactionHandling);
     Task InsertScriptRunError(string scriptName, string? sql, string errorSql, string errorMessage, long versionId);
     Task<bool> VersionTableExists();
+    Task<bool> GrateInternalTablesAreProperlyLogged();
     Task ChangeVersionStatus(string status, long versionId);
     Task DeleteVersionRecord(long versionId);
     void SetDefaultConnectionActive();

--- a/unittests/MariaDB/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/MariaDB/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,9 @@
+﻿using MariaDB.TestInfrastructure;
+
+namespace MariaDB.Bootstrapping;
+
+[Collection(nameof(MariaDbGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class Grate_Internal_Scripts(MariaDbGrateTestContext testContext, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.Grate_Internal_Scripts(testContext, testOutput);

--- a/unittests/Oracle/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/Oracle/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,9 @@
+﻿using Oracle.TestInfrastructure;
+
+namespace Oracle.Bootstrapping;
+
+[Collection(nameof(OracleGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class Grate_Internal_Scripts(OracleGrateTestContext testContext, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.Grate_Internal_Scripts(testContext, testOutput);

--- a/unittests/PostgreSQL/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/PostgreSQL/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,9 @@
+﻿using PostgreSQL.TestInfrastructure;
+
+namespace PostgreSQL.Bootstrapping;
+
+[Collection(nameof(PostgreSqlGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class Grate_Internal_Scripts(PostgreSqlGrateTestContext testContext, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.Grate_Internal_Scripts(testContext, testOutput);

--- a/unittests/SqlServer/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/SqlServer/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,9 @@
+﻿using SqlServer.TestInfrastructure;
+
+namespace SqlServer.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class Grate_Internal_Scripts(SqlServerGrateTestContext testContext, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.Grate_Internal_Scripts(testContext, testOutput);

--- a/unittests/SqlServerCaseSensitive/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/SqlServerCaseSensitive/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,9 @@
+﻿using SqlServerCaseSensitive.TestInfrastructure;
+
+namespace SqlServerCaseSensitive.Bootstrapping;
+
+[Collection(nameof(SqlServerGrateTestContext))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class Grate_Internal_Scripts(SqlServerGrateTestContext testContext, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.Grate_Internal_Scripts(testContext, testOutput);

--- a/unittests/Sqlite/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/Sqlite/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,11 @@
+﻿using Sqlite.TestInfrastructure;
+using TestCommon.TestInfrastructure;
+
+namespace Sqlite.Bootstrapping;
+
+
+[Collection(nameof(SqliteTestDatabase))]
+// ReSharper disable once InconsistentNaming
+// ReSharper disable once UnusedType.Global
+public class Grate_Internal_Scripts(SqliteGrateTestContext testContext, ITestOutputHelper testOutput)
+    : TestCommon.Generic.Bootstrapping.Grate_Internal_Scripts(testContext, testOutput);

--- a/unittests/TestCommon/Generic/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/Grate_Internal_Scripts.cs
@@ -38,17 +38,17 @@ public abstract class Grate_Internal_Scripts(IGrateTestContext context, ITestOut
         }
 
         string[] scripts;
-        string sql = $"SELECT script_name FROM {Context.Syntax.TableWithSchema("grate", "GrateScriptsRun")}";
+        string sql = $"""
+SELECT script_name 
+FROM {Context.Syntax.TableWithSchema("grate", "GrateScriptsRun")}
+WHERE script_name = '02_create_scripts_run_table.sql'
+""";
 
         using (var conn = Context.External.CreateDbConnection(db))
         {
             scripts = (await conn.QueryAsync<string>(sql)).ToArray();
         }
 
-        // There are three scripts, and these are run for the grate internal tables, and for the grate tables.
-        scripts.Should().HaveCount(3 * 2);
-        
-        //await Context.DropDatabase(db);
+        scripts.Should().HaveCount(1);
     }
-
 }

--- a/unittests/TestCommon/Generic/Bootstrapping/Grate_Internal_Scripts.cs
+++ b/unittests/TestCommon/Generic/Bootstrapping/Grate_Internal_Scripts.cs
@@ -1,0 +1,54 @@
+﻿using Dapper;
+using FluentAssertions;
+using grate.Configuration;
+using TestCommon.Generic.Running_MigrationScripts;
+using TestCommon.TestInfrastructure;
+using Xunit.Abstractions;
+using static grate.Configuration.KnownFolderKeys;
+
+namespace TestCommon.Generic.Bootstrapping;
+
+//[TestFixture]
+// ReSharper disable once InconsistentNaming
+public abstract class Grate_Internal_Scripts(IGrateTestContext context, ITestOutputHelper testOutput) 
+    : MigrationsScriptsBase(context, testOutput)
+{
+    [Fact]
+    public async Task Are_only_run_once()
+    {
+        var db = TestConfig.RandomDatabase();
+
+        var parent = CreateRandomTempDirectory();
+        var knownFolders = Folders.Default;
+        CreateDummySql(parent, knownFolders[Sprocs]);
+        
+        var config = GrateConfigurationBuilder.Create(Context.DefaultConfiguration)
+            .WithConnectionString(Context.ConnectionString(db))
+            .WithFolders(knownFolders)
+            .WithSqlFilesDirectory(parent)
+            .Build();
+        
+        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        {
+            await migrator.Migrate();
+        }
+        await using (var migrator = Context.Migrator.WithConfiguration(config))
+        {
+            await migrator.Migrate();
+        }
+
+        string[] scripts;
+        string sql = $"SELECT script_name FROM {Context.Syntax.TableWithSchema("grate", "GrateScriptsRun")}";
+
+        using (var conn = Context.External.CreateDbConnection(db))
+        {
+            scripts = (await conn.QueryAsync<string>(sql)).ToArray();
+        }
+
+        // There are three scripts, and these are run for the grate internal tables, and for the grate tables.
+        scripts.Should().HaveCount(3 * 2);
+        
+        //await Context.DropDatabase(db);
+    }
+
+}


### PR DESCRIPTION
The running of the scripts to create the grate tables ScriptsRun, ScriptsRunErrors and Version were always run in baseline mode, even after the scripts had been registered as run, so they were registered as run every time (even if they were only run once).

Fixes #524 