### PR TITLE
Chore: Set default testing SQL server docker image to server:2022-latest

### DIFF
--- a/unittests/SqlServer/TestInfrastructure/SqlServerTestContainerDatabase.cs
+++ b/unittests/SqlServer/TestInfrastructure/SqlServerTestContainerDatabase.cs
@@ -14,7 +14,7 @@ public record SqlServerTestContainerDatabase(
     : TestContainerDatabase(GrateTestConfig)
 {
     // Run with linux/amd86 on ARM architectures too, the docker emulation is good enough
-    public override string DockerImage => GrateTestConfig.DockerImage ?? "mcr.microsoft.com/mssql/server:2022-latest";
+    public override string DockerImage => GrateTestConfig.DockerImage ?? "mcr.microsoft.com/mssql/server:2019-latest";
     protected override int InternalPort => MsSqlBuilder.MsSqlPort;
     protected override string NetworkAlias => "sqlserver-test-container";
 

--- a/unittests/SqlServer/TestInfrastructure/SqlServerTestContainerDatabase.cs
+++ b/unittests/SqlServer/TestInfrastructure/SqlServerTestContainerDatabase.cs
@@ -14,7 +14,7 @@ public record SqlServerTestContainerDatabase(
     : TestContainerDatabase(GrateTestConfig)
 {
     // Run with linux/amd86 on ARM architectures too, the docker emulation is good enough
-    public override string DockerImage => GrateTestConfig.DockerImage ?? "mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04";
+    public override string DockerImage => GrateTestConfig.DockerImage ?? "mcr.microsoft.com/mssql/server:2022-latest";
     protected override int InternalPort => MsSqlBuilder.MsSqlPort;
     protected override string NetworkAlias => "sqlserver-test-container";
 


### PR DESCRIPTION
The tests in Github pipelines were not running properly. Change to 2022-latest image