### PR TITLE
[Sample] Added example of running a migration as part of automated tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <!--
       .net sdk
     -->
-    <PackageVersion Include="grate.sqlserver" Version="1.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,11 +3,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <ItemGroup>
     <!--
       .net sdk
     -->
+    <PackageVersion Include="grate.sqlserver" Version="1.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />

--- a/examples/test-integration/sample-test-integration/SampleDatabase/SampleDatabase.csproj
+++ b/examples/test-integration/sample-test-integration/SampleDatabase/SampleDatabase.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+  <ItemGroup>
+    <Content Include=".\db\**\*.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/examples/test-integration/sample-test-integration/SampleDatabase/db/sprocs/000_sample_proc.sql
+++ b/examples/test-integration/sample-test-integration/SampleDatabase/db/sprocs/000_sample_proc.sql
@@ -1,0 +1,7 @@
+
+create or alter proc sample_proc
+as
+
+ select 10 as [Result];
+ 
+GO

--- a/examples/test-integration/sample-test-integration/SampleDatabase/readme.md
+++ b/examples/test-integration/sample-test-integration/SampleDatabase/readme.md
@@ -1,0 +1,2 @@
+
+Your grate database project.  Nothing fancy needed here. 

--- a/examples/test-integration/sample-test-integration/Tests/DatabaseTest.cs
+++ b/examples/test-integration/sample-test-integration/Tests/DatabaseTest.cs
@@ -1,0 +1,20 @@
+﻿using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Tests;
+
+[Collection(nameof(SqlServerCollection))] // tell XUnit we need the SqlServer fixture running before this test starts
+public sealed class DatabaseTest
+{
+    [Fact]
+    public async Task CheckDatabaseConnectivityAndEnsureMigrationRan()
+    {
+        var connString = SqlServerFixture.SysAdminConnString; 
+		
+        await using var conn = new SqlConnection(connString);
+        var result = await conn.ExecuteScalarAsync<int>("sample_proc", commandType: CommandType.StoredProcedure);
+        Assert.Equal(10, result);
+    } 
+}

--- a/examples/test-integration/sample-test-integration/Tests/SqlServerFixture.cs
+++ b/examples/test-integration/sample-test-integration/Tests/SqlServerFixture.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Testcontainers.MsSql;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Tests;
+
+/// <summary>
+/// Helper class to run a SqlServer as part of the tests for migrations etc.  One 'server' per run instance.
+/// We run the grate migration as part of standing up the server so we have a fully populated database to test against.
+/// </summary>
+public sealed class SqlServerFixture : IAsyncLifetime
+{
+    private static MsSqlContainer SqlServer { get; }
+    
+    /// <summary>
+    /// The fully privileged sa connection string to our test database
+    /// </summary>
+    internal static string SysAdminConnString => SqlServer.GetConnectionString().Replace("Database=master", "Database=MyApp_IntegrationTests");
+    // Note: When testing real apps we often also have connection strings with application credentials in order to test permissions as part of the tests
+    
+    /// <summary>
+    /// This lets us pass messages to the xunit output window, in theory.
+    /// </summary>
+    private readonly IMessageSink _sink;
+
+    public SqlServerFixture(IMessageSink sink)
+    {
+        _sink = sink;
+    }
+    
+    static SqlServerFixture()
+    {
+        SqlServer = new MsSqlBuilder()
+            .WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04") // TestContainers recommend running a pinned image for repeatability
+            
+            // See https://github.com/testcontainers/testcontainers-dotnet/issues/1220#issuecomment-2248455959
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd", "-C", "-Q", "SELECT 1;") )
+            .Build();
+    }
+    
+    public async Task InitializeAsync()
+    {
+        await SqlServer.StartAsync();
+        Assert.Equal(TestcontainersStates.Running, SqlServer.State);
+        await RunDatabaseMigration();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (SqlServer.State == TestcontainersStates.Running)
+        {
+            await SqlServer.StopAsync();
+        }
+
+        await SqlServer.DisposeAsync();
+    }
+
+    private async Task RunDatabaseMigration(CancellationToken token = default)
+    {
+        var migration = new Process();
+        migration.StartInfo.RedirectStandardOutput = true;
+        migration.StartInfo.RedirectStandardError = true;
+        migration.StartInfo.CreateNoWindow = true;
+        migration.ErrorDataReceived += migration_OutputDataReceived;
+        migration.OutputDataReceived += migration_OutputDataReceived;
+        migration.EnableRaisingEvents = true;
+
+        migration.StartInfo.Arguments = $"--files=./db --env=IntegrationTest --connstring=\"{SysAdminConnString}\" --version=1.0 --silent ";
+
+#if Linux
+            migration.StartInfo.FileName = "grate";
+#elif Windows
+            migration.StartInfo.FileName = "grate.exe";
+#endif
+
+        migration.Start();
+
+        migration.BeginOutputReadLine();
+        migration.BeginErrorReadLine();
+
+        await migration.WaitForExitAsync(token);
+
+        Assert.True(migration.HasExited);
+        Assert.Equal(0, migration.ExitCode);
+    }
+    
+    private void migration_OutputDataReceived(object sender, DataReceivedEventArgs e)
+    {
+        _sink.OnMessage(new DiagnosticMessage(e.Data));
+    }
+}
+
+
+[CollectionDefinition(nameof(SqlServerCollection))]
+public class SqlServerCollection : ICollectionFixture<SqlServerFixture>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces so the unit tests can opt in to the database infrastructure.
+}

--- a/examples/test-integration/sample-test-integration/Tests/Tests.csproj
+++ b/examples/test-integration/sample-test-integration/Tests/Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <!-- Depending on where we run our tests we might need a windows or linux process name -->
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsLinux)'=='true'">
+    <DefineConstants>Linux</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Testcontainers.MsSql" Version="3.10.0"/>
+    <PackageReference Include="xunit" Version="2.9.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SampleDatabase\SampleDatabase.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/test-integration/sample-test-integration/global.json
+++ b/examples/test-integration/sample-test-integration/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/examples/test-integration/sample-test-integration/readme.md
+++ b/examples/test-integration/sample-test-integration/readme.md
@@ -1,0 +1,8 @@
+# Example of using grate in Automated Tests
+
+A simplified example of one way to use `grate` in your automated tests.
+
+This is certainly not the only way of integrating `grate` into your tests, but is a pattern that's been used in multiple companies with success.
+
+⚠️ There's an implicit assumption that `grate` is installed on the system running the tests.  Ensure you have a 
+step in your pipeline to install `grate` on the build server for CI (and that it's installed locally for development).

--- a/examples/test-integration/sample-test-integration/sample-test-integration.sln
+++ b/examples/test-integration/sample-test-integration/sample-test-integration.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{5CD60F63-9EDF-49F5-8EE0-AA73ABA797DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleDatabase", "SampleDatabase\SampleDatabase.csproj", "{D6C52C5E-3119-4EF8-8E95-BDECAB6101E4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{865B6A7B-78C9-4A2C-9280-95C8402C9F67}"
+	ProjectSection(SolutionItems) = preProject
+		readme.md = readme.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5CD60F63-9EDF-49F5-8EE0-AA73ABA797DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CD60F63-9EDF-49F5-8EE0-AA73ABA797DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CD60F63-9EDF-49F5-8EE0-AA73ABA797DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CD60F63-9EDF-49F5-8EE0-AA73ABA797DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6C52C5E-3119-4EF8-8E95-BDECAB6101E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6C52C5E-3119-4EF8-8E95-BDECAB6101E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6C52C5E-3119-4EF8-8E95-BDECAB6101E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6C52C5E-3119-4EF8-8E95-BDECAB6101E4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
There was a comment in an issue a while back about running grate as part of tests.  This is a simplified example of how we've used it succesfully for multiple orgs.