### PR TITLE
fix(sql-server): Remove text and ntext when creating grate internal tables

### DIFF
--- a/src/grate.core/Migration/GrateMigrator.cs
+++ b/src/grate.core/Migration/GrateMigrator.cs
@@ -677,7 +677,13 @@ internal record GrateMigrator : IGrateMigrator
                 $"VersionTableLowerCase={thisConfig.VersionTableName.ToLower()}"
             ],
             
-            Environment = GrateEnvironment.Internal
+            Environment = GrateEnvironment.Internal,
+            /* 
+            note for `grate internal migration` only: 
+            this flag will allow grate to `bypass the error` of one time script change.
+            We will consider removing this flag in future.
+            */
+            WarnOnOneTimeScriptChanges = true
         };
     }
 

--- a/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/02_create_scripts_run_table.sql
@@ -1,12 +1,14 @@
-CREATE TABLE {{SchemaName}}.{{ScriptsRunTable}}(
-    id bigint IDENTITY(1,1) NOT NULL,
-    version_id BIGINT NULL,
-    script_name nvarchar(255) NULL,
-    text_of_script text NULL,
-    text_hash nvarchar(512) NULL,
-    one_time_script bit NULL,
-    entry_date datetime NULL,
-    modified_date datetime NULL,
-    entered_by nvarchar(50) NULL,
-    CONSTRAINT PK_{{ScriptsRunTable}}_id PRIMARY KEY CLUSTERED (id)
-)
+-- backwards compatibility, if the table already exists, let update scripts fix text column type issue
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'{{SchemaName}}.{{ScriptsRunTable}}') AND type in (N'U'))
+    CREATE TABLE {{SchemaName}}.{{ScriptsRunTable}}(
+        id bigint IDENTITY(1,1) NOT NULL,
+        version_id BIGINT NULL,
+        script_name nvarchar(255) NULL,
+        text_of_script nvarchar(max) NULL,
+        text_hash nvarchar(512) NULL,
+        one_time_script bit NULL,
+        entry_date datetime NULL,
+        modified_date datetime NULL,
+        entered_by nvarchar(50) NULL,
+        CONSTRAINT PK_{{ScriptsRunTable}}_id PRIMARY KEY CLUSTERED (id)
+    )

--- a/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
+++ b/src/grate.sqlserver/Bootstrapping/Sql/Baseline/up/03_create_scripts_run_errors_table.sql
@@ -1,14 +1,15 @@
-CREATE TABLE {{SchemaName}}.{{ScriptsRunErrorsTable}}(
-    id bigint IDENTITY(1,1) NOT NULL,
-    repository_path nvarchar(255) NULL,
-    version nvarchar(50) NULL,
-    script_name nvarchar(255) NULL,
-    text_of_script text NULL,
-    erroneous_part_of_script text NULL,
-    error_message text NULL,
-    entry_date datetime NULL,
-    modified_date datetime NULL,
-    entered_by nvarchar(50) NULL,
-    CONSTRAINT PK_{{ScriptsRunErrorsTable}}_id PRIMARY KEY CLUSTERED (id)
-)
-
+-- backwards compatibility, if the table already exists, let update scripts fix text column type issue
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'{{SchemaName}}.{{ScriptsRunErrorsTable}}') AND type in (N'U'))
+    CREATE TABLE {{SchemaName}}.{{ScriptsRunErrorsTable}}(
+        id bigint IDENTITY(1,1) NOT NULL,
+        repository_path nvarchar(255) NULL,
+        version nvarchar(50) NULL,
+        script_name nvarchar(255) NULL,
+        text_of_script nvarchar(max) NULL,
+        erroneous_part_of_script nvarchar(max) NULL,
+        error_message nvarchar(max) NULL,
+        entry_date datetime NULL,
+        modified_date datetime NULL,
+        entered_by nvarchar(50) NULL,
+        CONSTRAINT PK_{{ScriptsRunErrorsTable}}_id PRIMARY KEY CLUSTERED (id)
+    )


### PR DESCRIPTION
This PR intends to fix issue #591 by changing the bootstrap script to nvarchar(max) instead of text for SQL server.